### PR TITLE
Pin Widgets deployment target to iOS 26.0

### DIFF
--- a/Shellbee.xcodeproj/project.pbxproj
+++ b/Shellbee.xcodeproj/project.pbxproj
@@ -868,6 +868,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "Shellbee Widgets";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -909,6 +910,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "Shellbee Widgets";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Summary
- Sets `IPHONEOS_DEPLOYMENT_TARGET = 26.0` on the Shellbee Widgets target for both Debug and Release configurations.

## Scope
- Shellbee.xcodeproj/project.pbxproj (Widgets target only)

## Test plan
- [ ] CI green
- [ ] Widgets target builds on iOS 26 simulator