### PR TITLE
Remove push-to-main trigger from Full CI

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -51,11 +51,13 @@ jobs:
       - name: Cache SwiftPM dependencies
         uses: actions/cache@v4
         with:
+          # Only cache the source checkouts and SwiftPM's global cache — not
+          # the artifacts directory. Artifacts contain prebuilt xcframeworks
+          # that xcodebuild re-validates on every run (~2 min), which negated
+          # the cache win when we included them.
           path: |
-            ${{ github.workspace }}/DerivedData/SourcePackages
+            ${{ github.workspace }}/DerivedData/SourcePackages/checkouts
             ~/Library/Caches/org.swift.swiftpm
-          # Invalidate when Package.resolved changes (deps added/updated)
-          # or when the Xcode version changes (forces rebuild of binaries).
           key: spm-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             spm-${{ runner.os }}-

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -48,6 +48,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Cache SwiftPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/DerivedData/SourcePackages
+            ~/Library/Caches/org.swift.swiftpm
+          # Invalidate when Package.resolved changes (deps added/updated)
+          # or when the Xcode version changes (forces rebuild of binaries).
+          key: spm-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
       - name: Select latest Xcode
         run: |
           LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -n1)

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -53,6 +53,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache SwiftPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/DerivedData/SourcePackages
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
       - name: Start mock Z2M bridge (docker compose)
         run: |
           # Full CI runs the Z2MIntegrationTests against the real mock bridge.
@@ -195,6 +205,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Cache SwiftPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/DerivedData/SourcePackages
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
 
       - name: Select latest Xcode
         run: |

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,24 +1,15 @@
 name: CI (Full)
 
 # Complete suite: unit tests + UI tests. Runs in three situations:
-#   1. Every push to main (catches regressions introduced by merges)
-#   2. Nightly at 03:00 UTC (catches environmental / flaky issues)
-#   3. On-demand: manually from the Actions tab, or by labeling a PR
+#   1. Nightly at 03:00 UTC (catches environmental / flaky issues)
+#   2. On-demand: manually from the Actions tab, or by labeling a PR
 #      with `run-ui-tests` when you want extra confidence before merge
 #
 # Typical duration: 15-25 min. Not required for PR merge — see ci-fast.yml
-# for the required check.
+# for the required check. Intentionally does NOT run on every push to main,
+# to avoid a red check appearing on the trunk for transient UI flakes.
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - '**/*.md'
-      - 'docker/**'
-      - 'scripts/**'
-      - 'docs/**'
-      - '.gitignore'
-      - 'PRIVACY.md'
   schedule:
     # 03:00 UTC daily. Cron syntax: minute hour day month day-of-week.
     - cron: '0 3 * * *'

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ${{ github.workspace }}/DerivedData/SourcePackages
+            ${{ github.workspace }}/DerivedData/SourcePackages/checkouts
             ~/Library/Caches/org.swift.swiftpm
           key: spm-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
@@ -210,7 +210,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ${{ github.workspace }}/DerivedData/SourcePackages
+            ${{ github.workspace }}/DerivedData/SourcePackages/checkouts
             ~/Library/Caches/org.swift.swiftpm
           key: spm-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |


### PR DESCRIPTION
## Summary
- Full CI no longer runs on every push to `main` — only nightly, manual dispatch, or PR label.
- Fast CI still runs on every PR and push to `main` (unchanged).

## Why
Every merge was triggering a 20–25 min Full run. For solo-maintained development, the signal isn't worth the noise of a possibly-red check sitting on `main`. Nightly coverage + on-demand trigger before releases is enough.

## Scope
`.github/workflows/ci-full.yml` only.

## Release notes
n/a — infra.