### PR TITLE
Fix z2m settings bugs; restructure Logging; UI polish

### DIFF
--- a/Shellbee.xcodeproj/project.pbxproj
+++ b/Shellbee.xcodeproj/project.pbxproj
@@ -209,6 +209,8 @@
 				Features/Settings/FrontendSettingsView.swift,
 				Features/Settings/HealthSettingsView.swift,
 				Features/Settings/HomeAssistantSettingsView.swift,
+				Features/Settings/LoggingBasicView.swift,
+				Features/Settings/LoggingHubView.swift,
 				Features/Settings/LoggingSettingsView.swift,
 				Features/Settings/MainSettingsView.swift,
 				Features/Settings/MQTTSettingsView.swift,

--- a/Shellbee/App/AppEnvironment.swift
+++ b/Shellbee/App/AppEnvironment.swift
@@ -95,6 +95,12 @@ final class AppEnvironment {
         session.send(topic: topic, payload: payload)
     }
 
+    /// Sends a `bridge/request/options` request with the payload wrapped in
+    /// the `{"options": {...}}` envelope that z2m requires.
+    func sendBridgeOptions(_ options: [String: JSONValue]) {
+        send(topic: Z2MTopics.Request.options, payload: .object(["options": .object(options)]))
+    }
+
     func sendDeviceState(_ friendlyName: String, payload: JSONValue) {
         send(topic: Z2MTopics.deviceSet(friendlyName), payload: payload)
     }

--- a/Shellbee/Core/Models/BridgeSettings.swift
+++ b/Shellbee/Core/Models/BridgeSettings.swift
@@ -40,14 +40,24 @@ struct BridgeSettings: Codable, Sendable, Equatable {
 
 extension BridgeSettings {
     enum LogLevel: String, Codable, Sendable, CaseIterable {
-        case debug, info, warn, error
+        case debug, info, warning, error
 
         var label: String {
             switch self {
             case .debug: return "Debug"
             case .info: return "Info"
-            case .warn: return "Warning"
+            case .warning: return "Warning"
             case .error: return "Error"
+            }
+        }
+
+        init?(rawValue: String) {
+            switch rawValue.lowercased() {
+            case "debug": self = .debug
+            case "info": self = .info
+            case "warning", "warn": self = .warning
+            case "error": self = .error
+            default: return nil
             }
         }
     }

--- a/Shellbee/Core/Networking/Z2MMessageRouter.swift
+++ b/Shellbee/Core/Networking/Z2MMessageRouter.swift
@@ -60,6 +60,13 @@ struct Z2MMessageRouter: Sendable {
             return .deviceOTACheckResponse(response)
 
         case Z2MTopics.bridgeResponseOptions, Z2MTopics.bridgeResponseInfo:
+            if let obj = raw.payload.object,
+               obj["status"]?.stringValue == "error",
+               let errorMsg = obj["error"]?.stringValue {
+                return .operationError(Z2MOperationError(
+                    id: UUID(), topic: raw.topic, message: errorMsg, timestamp: .now
+                ))
+            }
             return .bridgeResponse(topic: raw.topic, data: raw.payload)
 
         case Z2MTopics.bridgeResponseTouchlinkScan:

--- a/Shellbee/Core/Store/AppStore.swift
+++ b/Shellbee/Core/Store/AppStore.swift
@@ -125,16 +125,14 @@ final class AppStore {
             }
 
         case .bridgeResponse(_, let payload):
-            if let data = payload.object?["data"] {
-                let restartRequired = data.object?["restart_required"]?.boolValue
-                let config = data.decode(BridgeConfig.self)
-                
-                if let info = bridgeInfo {
-                    bridgeInfo = info.copyUpdating(
-                        restartRequired: restartRequired,
-                        config: config
-                    )
-                }
+            // The options/info responses carry only `{restart_required}` (and
+            // echo the request on error). The full config is delivered via the
+            // separate `bridge/info` topic, so don't try to decode config here
+            // — doing so would overwrite the real config with all-nils.
+            guard payload.object?["status"]?.stringValue == "ok" else { break }
+            if let restartRequired = payload.object?["data"]?.object?["restart_required"]?.boolValue,
+               let info = bridgeInfo {
+                bridgeInfo = info.copyUpdating(restartRequired: restartRequired)
             }
 
         case .bridgeHealth(let health):

--- a/Shellbee/Features/Devices/AddReportingSheet.swift
+++ b/Shellbee/Features/Devices/AddReportingSheet.swift
@@ -3,25 +3,42 @@ import SwiftUI
 struct AddReportingSheet: View {
     @Environment(\.dismiss) private var dismiss
     let device: Device
-    let availableClusters: [String]
+    let endpointClusters: [(endpoint: Int, clusters: [String])]
     let onAdd: (ReportingConfig) -> Void
 
+    @State private var endpoint: Int = 0
     @State private var cluster: String = ""
     @State private var attribute: String = ""
     @State private var minInterval: Int = 1
     @State private var maxInterval: Int = 3600
     @State private var reportableChange: Int = 1
 
-    private var canSave: Bool { !cluster.isEmpty && !attribute.isEmpty }
+    private var endpoints: [Int] { endpointClusters.map(\.endpoint) }
+
+    private var clustersForEndpoint: [String] {
+        endpointClusters.first { $0.endpoint == endpoint }?.clusters ?? []
+    }
+
+    private var canSave: Bool {
+        endpoint != 0 && !cluster.isEmpty && !attribute.isEmpty
+    }
 
     var body: some View {
         NavigationStack {
             Form {
                 Section("Data Source") {
-                    if !availableClusters.isEmpty {
+                    if endpoints.count > 1 {
+                        Picker("Endpoint", selection: $endpoint) {
+                            Text("Choose").tag(0)
+                            ForEach(endpoints, id: \.self) { ep in
+                                Text("EP \(ep)").tag(ep)
+                            }
+                        }
+                    }
+                    if !clustersForEndpoint.isEmpty {
                         Picker("Cluster", selection: $cluster) {
                             Text("Choose").tag("")
-                            ForEach(availableClusters, id: \.self) { c in
+                            ForEach(clustersForEndpoint, id: \.self) { c in
                                 Text(c).tag(c)
                             }
                         }
@@ -55,6 +72,7 @@ struct AddReportingSheet: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Add") {
                         onAdd(ReportingConfig(
+                            endpoint: endpoint,
                             cluster: cluster, attribute: attribute,
                             minInterval: minInterval, maxInterval: maxInterval,
                             reportableChange: reportableChange
@@ -66,7 +84,13 @@ struct AddReportingSheet: View {
                 }
             }
             .onAppear {
-                if cluster.isEmpty, let first = availableClusters.first { cluster = first }
+                if endpoint == 0, let first = endpoints.first { endpoint = first }
+                if cluster.isEmpty, let first = clustersForEndpoint.first { cluster = first }
+            }
+            .onChange(of: endpoint) { _, _ in
+                if !clustersForEndpoint.contains(cluster) {
+                    cluster = clustersForEndpoint.first ?? ""
+                }
             }
         }
     }
@@ -75,6 +99,6 @@ struct AddReportingSheet: View {
 #Preview {
     AddReportingSheet(
         device: .preview,
-        availableClusters: ["genOnOff", "genLevelCtrl", "lightingColorCtrl"]
+        endpointClusters: [(1, ["genOnOff", "genLevelCtrl", "lightingColorCtrl"])]
     ) { _ in }
 }

--- a/Shellbee/Features/Devices/DeviceBindView.swift
+++ b/Shellbee/Features/Devices/DeviceBindView.swift
@@ -85,7 +85,6 @@ struct DeviceBindView: View {
             payload["clusters"] = .array(clusters.map { .string($0) })
         }
         environment.send(topic: Z2MTopics.Request.deviceBind, payload: .object(payload))
-        refreshDevices()
     }
 
     private func unbind(_ binding: ParsedBinding) {
@@ -98,11 +97,6 @@ struct DeviceBindView: View {
                 "clusters": .array([.string(binding.cluster)])
             ])
         )
-        refreshDevices()
-    }
-
-    private func refreshDevices() {
-        environment.send(topic: Z2MTopics.Request.devices, payload: .object([:]))
     }
 
     private func resolveTarget(_ binding: ParsedBinding) -> String {

--- a/Shellbee/Features/Devices/DeviceDetailView.swift
+++ b/Shellbee/Features/Devices/DeviceDetailView.swift
@@ -25,6 +25,7 @@ struct DeviceDetailView: View {
                     state: state,
                     isAvailable: isAvailable,
                     otaStatus: otaStatus,
+                    lastSeenEnabled: (environment.store.bridgeInfo?.config?.advanced?.lastSeen ?? "disable") != "disable",
                     onRenameTapped: { showRenameSheet = true }
                 )
                     .listRowInsets(EdgeInsets())

--- a/Shellbee/Features/Devices/DeviceReportingView.swift
+++ b/Shellbee/Features/Devices/DeviceReportingView.swift
@@ -13,16 +13,17 @@ struct DeviceReportingView: View {
         ConfiguredReporting.parse(from: currentDevice.endpoints ?? [:])
     }
 
-    private var availableClusters: [String] {
-        var clusters: Set<String> = []
-        for (_, value) in currentDevice.endpoints ?? [:] {
-            if let obj = value.object,
-               let clustersObj = obj["clusters"]?.object,
-               let arr = clustersObj["input"]?.array {
-                clusters.formUnion(arr.compactMap(\.stringValue))
-            }
+    private var endpointClusters: [(endpoint: Int, clusters: [String])] {
+        var result: [(Int, [String])] = []
+        for (key, value) in currentDevice.endpoints ?? [:] {
+            guard let ep = Int(key),
+                  let obj = value.object,
+                  let clustersObj = obj["clusters"]?.object,
+                  let arr = clustersObj["input"]?.array else { continue }
+            let clusters = arr.compactMap(\.stringValue).sorted()
+            result.append((ep, clusters))
         }
-        return clusters.sorted()
+        return result.sorted { $0.0 < $1.0 }
     }
 
     var body: some View {
@@ -51,7 +52,7 @@ struct DeviceReportingView: View {
         .sheet(isPresented: $showAddSheet) {
             AddReportingSheet(
                 device: currentDevice,
-                availableClusters: availableClusters
+                endpointClusters: endpointClusters
             ) { config in
                 sendReportingConfig(config)
             }
@@ -63,6 +64,7 @@ struct DeviceReportingView: View {
             topic: Z2MTopics.Request.deviceReportingConfigure,
             payload: .object([
                 "id": .string(currentDevice.friendlyName),
+                "endpoint": .int(config.endpoint),
                 "cluster": .string(config.cluster),
                 "attribute": .string(config.attribute),
                 "minimum_report_interval": .int(config.minInterval),
@@ -105,6 +107,7 @@ struct ConfiguredReporting: Identifiable {
 }
 
 struct ReportingConfig {
+    var endpoint: Int
     var cluster: String
     var attribute: String
     var minInterval: Int

--- a/Shellbee/Features/Logs/LogDetailView.swift
+++ b/Shellbee/Features/Logs/LogDetailView.swift
@@ -108,7 +108,8 @@ struct LogDetailView: View {
                     device: device,
                     state: environment.store.state(for: device.friendlyName),
                     isAvailable: environment.store.isAvailable(device.friendlyName),
-                    otaStatus: environment.store.otaStatus(for: device.friendlyName)
+                    otaStatus: environment.store.otaStatus(for: device.friendlyName),
+                    lastSeenEnabled: (environment.store.bridgeInfo?.config?.advanced?.lastSeen ?? "disable") != "disable"
                 )
                 NavigationLink(destination: DeviceDetailView(device: device)) { EmptyView() }
                     .opacity(0)

--- a/Shellbee/Features/Settings/AppNotificationSettingsView.swift
+++ b/Shellbee/Features/Settings/AppNotificationSettingsView.swift
@@ -60,7 +60,7 @@ struct AppNotificationSettingsView: View {
     private var aboutSection: some View {
         Section {
             NavigationLink {
-                MainSettingsView(highlight: .logLevel)
+                LoggingBasicView(highlight: .logLevel)
             } label: {
                 LabeledContent("Bridge Log Level", value: displayedLevel.capitalized)
             }

--- a/Shellbee/Features/Settings/AppPerformanceView.swift
+++ b/Shellbee/Features/Settings/AppPerformanceView.swift
@@ -10,11 +10,13 @@ struct AppPerformanceView: View {
                 InlineIntField(
                     "Concurrent Requests",
                     value: $concurrency,
+                    unit: "requests",
                     range: OTABulkOperationQueue.concurrencyRange
                 )
                 InlineIntField(
                     "Device Timeout",
                     value: $checkTimeout,
+                    unit: "s",
                     range: OTABulkOperationQueue.checkTimeoutRange
                 )
             } header: {

--- a/Shellbee/Features/Settings/AvailabilitySettingsView.swift
+++ b/Shellbee/Features/Settings/AvailabilitySettingsView.swift
@@ -70,7 +70,7 @@ struct AvailabilitySettingsView: View {
             }
         }
         .discardChangesAlert(hasChanges: hasChanges, isPresented: $showingDiscardAlert) { loadFromStore(); dismiss() }
-        .task { loadFromStore() }
+        .reloadOnBridgeInfo(info: environment.store.bridgeInfo, hasChanges: hasChanges, load: loadFromStore)
     }
 
     private func loadFromStore() {
@@ -99,7 +99,7 @@ struct AvailabilitySettingsView: View {
                 "passive": .object(["timeout": .int(passiveTimeout)])
             ])
         ]
-        environment.send(topic: Z2MTopics.Request.options, payload: .object(payload))
+        environment.sendBridgeOptions(payload)
     }
 }
 

--- a/Shellbee/Features/Settings/FrontendSettingsView.swift
+++ b/Shellbee/Features/Settings/FrontendSettingsView.swift
@@ -98,7 +98,7 @@ struct FrontendSettingsView: View {
             }
         }
         .discardChangesAlert(hasChanges: hasChanges, isPresented: $showingDiscardAlert) { loadFromStore(); dismiss() }
-        .task { loadFromStore() }
+        .reloadOnBridgeInfo(info: environment.store.bridgeInfo, hasChanges: hasChanges, load: loadFromStore)
     }
 
     private func loadFromStore() {
@@ -127,7 +127,7 @@ struct FrontendSettingsView: View {
         if !authToken.isEmpty { frontend["auth_token"] = .string(authToken) }
         if !sslCert.isEmpty { frontend["ssl_cert"] = .string(sslCert) }
         if !sslKey.isEmpty { frontend["ssl_key"] = .string(sslKey) }
-        environment.send(topic: Z2MTopics.Request.options, payload: .object(["frontend": .object(frontend)]))
+        environment.sendBridgeOptions(["frontend": .object(frontend)])
         authToken = ""; sslCert = ""; sslKey = ""
     }
 }

--- a/Shellbee/Features/Settings/HealthSettingsView.swift
+++ b/Shellbee/Features/Settings/HealthSettingsView.swift
@@ -44,7 +44,7 @@ struct HealthSettingsView: View {
             }
         }
         .discardChangesAlert(hasChanges: hasChanges, isPresented: $showingDiscardAlert) { loadFromStore(); dismiss() }
-        .task { loadFromStore() }
+        .reloadOnBridgeInfo(info: environment.store.bridgeInfo, hasChanges: hasChanges, load: loadFromStore)
     }
 
     private func loadFromStore() {
@@ -58,7 +58,7 @@ struct HealthSettingsView: View {
             "interval": .int(interval),
             "reset_on_check": .bool(resetOnCheck)
         ]
-        environment.send(topic: Z2MTopics.Request.options, payload: .object(["health": .object(health)]))
+        environment.sendBridgeOptions(["health": .object(health)])
     }
 }
 

--- a/Shellbee/Features/Settings/HomeAssistantSettingsView.swift
+++ b/Shellbee/Features/Settings/HomeAssistantSettingsView.swift
@@ -63,7 +63,7 @@ struct HomeAssistantSettingsView: View {
             }
         }
         .discardChangesAlert(hasChanges: hasChanges, isPresented: $showingDiscardAlert) { loadFromStore(); dismiss() }
-        .task { loadFromStore() }
+        .reloadOnBridgeInfo(info: environment.store.bridgeInfo, hasChanges: hasChanges, load: loadFromStore)
     }
 
     private func loadFromStore() {
@@ -83,7 +83,7 @@ struct HomeAssistantSettingsView: View {
             "legacy_action_sensor": .bool(legacyActionSensor),
             "experimental_event_entities": .bool(experimentalEventEntities)
         ]
-        environment.send(topic: Z2MTopics.Request.options, payload: .object(["homeassistant": .object(ha)]))
+        environment.sendBridgeOptions(["homeassistant": .object(ha)])
     }
 }
 

--- a/Shellbee/Features/Settings/LoggingBasicView.swift
+++ b/Shellbee/Features/Settings/LoggingBasicView.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+struct LoggingBasicView: View {
+    @Environment(AppEnvironment.self) private var environment
+    @Environment(\.dismiss) private var dismiss
+
+    let highlight: SettingsHighlight?
+
+    init(highlight: SettingsHighlight? = nil) {
+        self.highlight = highlight
+    }
+
+    @State private var logLevel: BridgeSettings.LogLevel = .info
+    @State private var logRotation: Bool = true
+    @State private var logDirectoriesToKeep: Int = 10
+
+    @State private var showingDiscardAlert = false
+    @State private var logLevelHighlighted = false
+
+    private var hasChanges: Bool {
+        guard let info = environment.store.bridgeInfo else { return false }
+        let advanced = info.config?.advanced
+        return logLevel.rawValue != info.logLevel
+            || logRotation != (advanced?.logRotation ?? true)
+            || logDirectoriesToKeep != (advanced?.logDirectoriesToKeep ?? 10)
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("Log Level", selection: $logLevel) {
+                    ForEach(BridgeSettings.LogLevel.allCases, id: \.self) { level in
+                        Text(level.label).tag(level)
+                    }
+                }
+                .listRowBackground(
+                    logLevelHighlighted
+                        ? Color.accentColor.opacity(0.25)
+                        : Color(.secondarySystemGroupedBackground)
+                )
+            } footer: {
+                Text("Controls how verbose the bridge logs are.")
+            }
+
+            Section {
+                Toggle("Log Rotation", isOn: $logRotation)
+                InlineIntField("Directories to Keep", value: $logDirectoriesToKeep, range: 5...1000)
+            } header: {
+                Text("Log Files")
+            } footer: {
+                Text("Log rotation deletes old log directories automatically. Adjust how many to keep on disk.")
+            }
+        }
+        .navigationTitle("Basic")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if hasChanges {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { showingDiscardAlert = true }
+                }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Apply") { applyChanges() }
+                    .disabled(!hasChanges)
+            }
+        }
+        .discardChangesAlert(hasChanges: hasChanges, isPresented: $showingDiscardAlert) { loadFromStore(); dismiss() }
+        .reloadOnBridgeInfo(info: environment.store.bridgeInfo, hasChanges: hasChanges, load: loadFromStore)
+        .task {
+            guard highlight == .logLevel else { return }
+            try? await Task.sleep(for: .milliseconds(350))
+            withAnimation(.easeInOut(duration: 0.25)) { logLevelHighlighted = true }
+            try? await Task.sleep(for: .milliseconds(900))
+            withAnimation(.easeInOut(duration: 0.6)) { logLevelHighlighted = false }
+        }
+    }
+
+    private func loadFromStore() {
+        guard let info = environment.store.bridgeInfo else { return }
+        logLevel = BridgeSettings.LogLevel(rawValue: info.logLevel) ?? .info
+        let advanced = info.config?.advanced
+        logRotation = advanced?.logRotation ?? true
+        logDirectoriesToKeep = advanced?.logDirectoriesToKeep ?? 10
+    }
+
+    private func applyChanges() {
+        guard let info = environment.store.bridgeInfo else { return }
+        let advanced = info.config?.advanced
+        var changes: [String: JSONValue] = [:]
+
+        if logLevel.rawValue != info.logLevel {
+            changes["log_level"] = .string(logLevel.rawValue)
+        }
+        if logRotation != (advanced?.logRotation ?? true) {
+            changes["log_rotation"] = .bool(logRotation)
+        }
+        if logDirectoriesToKeep != (advanced?.logDirectoriesToKeep ?? 10) {
+            changes["log_directories_to_keep"] = .int(logDirectoriesToKeep)
+        }
+
+        guard !changes.isEmpty else { return }
+        environment.sendBridgeOptions(["advanced": .object(changes)])
+    }
+}
+
+#Preview {
+    NavigationStack {
+        LoggingBasicView().environment(AppEnvironment())
+    }
+}

--- a/Shellbee/Features/Settings/LoggingHubView.swift
+++ b/Shellbee/Features/Settings/LoggingHubView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct LoggingHubView: View {
+    let highlight: SettingsHighlight?
+
+    init(highlight: SettingsHighlight? = nil) {
+        self.highlight = highlight
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                NavigationLink {
+                    LoggingBasicView(highlight: highlight)
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Basic")
+                        Text("Log level and log file retention.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                NavigationLink {
+                    LoggingSettingsView()
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Advanced")
+                        Text("Outputs, formats, and debug namespace filter.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Logging")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        LoggingHubView().environment(AppEnvironment())
+    }
+}

--- a/Shellbee/Features/Settings/LoggingSettingsView.swift
+++ b/Shellbee/Features/Settings/LoggingSettingsView.swift
@@ -79,7 +79,7 @@ struct LoggingSettingsView: View {
                 Text("Regular expression to suppress debug messages from matching namespaces. Leave empty to log all namespaces.")
             }
         }
-        .navigationTitle("Log Output")
+        .navigationTitle("Advanced")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             if hasChanges {
@@ -93,7 +93,7 @@ struct LoggingSettingsView: View {
             }
         }
         .discardChangesAlert(hasChanges: hasChanges, isPresented: $showingDiscardAlert) { loadFromStore(); dismiss() }
-        .task { loadFromStore() }
+        .reloadOnBridgeInfo(info: environment.store.bridgeInfo, hasChanges: hasChanges, load: loadFromStore)
     }
 
     private func loadFromStore() {
@@ -118,7 +118,7 @@ struct LoggingSettingsView: View {
         ]
         if !logDirectory.isEmpty { advanced["log_directory"] = .string(logDirectory) }
         if !logDebugNamespaceIgnore.isEmpty { advanced["log_debug_namespace_ignore"] = .string(logDebugNamespaceIgnore) }
-        environment.send(topic: Z2MTopics.Request.options, payload: .object(["advanced": .object(advanced)]))
+        environment.sendBridgeOptions(["advanced": .object(advanced)])
     }
 }
 

--- a/Shellbee/Features/Settings/MQTTSettingsView.swift
+++ b/Shellbee/Features/Settings/MQTTSettingsView.swift
@@ -130,7 +130,7 @@ struct MQTTSettingsView: View {
         } message: {
             Text("Applying these changes with an empty password may remove existing credentials from the server. Do you want to proceed?")
         }
-        .task { loadFromStore() }
+        .reloadOnBridgeInfo(info: environment.store.bridgeInfo, hasChanges: hasChanges, load: loadFromStore)
     }
 
     private func applyChanges() {
@@ -175,7 +175,7 @@ struct MQTTSettingsView: View {
             "maximum_packet_size": .int(maximumPacketSize),
             "qos": .int(qos)
         ]
-        environment.send(topic: Z2MTopics.Request.options, payload: .object(["mqtt": .object(mqtt)]))
+        environment.sendBridgeOptions(["mqtt": .object(mqtt)])
     }
 }
 

--- a/Shellbee/Features/Settings/MainSettingsView.swift
+++ b/Shellbee/Features/Settings/MainSettingsView.swift
@@ -4,13 +4,6 @@ struct MainSettingsView: View {
     @Environment(AppEnvironment.self) private var environment
     @Environment(\.dismiss) private var dismiss
 
-    let highlight: SettingsHighlight?
-
-    init(highlight: SettingsHighlight? = nil) {
-        self.highlight = highlight
-    }
-
-    @State private var logLevel: BridgeSettings.LogLevel = .info
     @State private var lastSeen: BridgeSettings.LastSeenFormat = .disabled
     @State private var elapsed: Bool = false
     @State private var cacheState: Bool = true
@@ -18,25 +11,19 @@ struct MainSettingsView: View {
     @State private var cacheStateSendOnStartup: Bool = true
     @State private var output: BridgeSettings.OutputFormat = .json
     @State private var timestampFormat: String = "YYYY-MM-DD HH:mm:ss"
-    @State private var logRotation: Bool = true
-    @State private var logDirectoriesToKeep: Int = 10
 
     @State private var showingDiscardAlert = false
-    @State private var logLevelHighlighted = false
 
     private var hasChanges: Bool {
         guard let info = environment.store.bridgeInfo else { return false }
         let advanced = info.config?.advanced
-        return logLevel.rawValue != info.logLevel
-            || lastSeen.rawValue != (advanced?.lastSeen ?? "disable")
+        return lastSeen.rawValue != (advanced?.lastSeen ?? "disable")
             || elapsed != (advanced?.elapsed ?? false)
             || cacheState != (advanced?.cacheState ?? true)
             || cacheStatePersistent != (advanced?.cacheStatePersistent ?? true)
             || cacheStateSendOnStartup != (advanced?.cacheStateSendOnStartup ?? true)
             || output.rawValue != (advanced?.output ?? "json")
             || timestampFormat != (advanced?.timestampFormat ?? "YYYY-MM-DD HH:mm:ss")
-            || logRotation != (advanced?.logRotation ?? true)
-            || logDirectoriesToKeep != (advanced?.logDirectoriesToKeep ?? 10)
     }
 
     private var serverOutputIsAttributeOnly: Bool {
@@ -45,32 +32,6 @@ struct MainSettingsView: View {
 
     var body: some View {
         Form {
-            Section {
-                Picker("Log Level", selection: $logLevel) {
-                    ForEach(BridgeSettings.LogLevel.allCases, id: \.self) { level in
-                        Text(level.label).tag(level)
-                    }
-                }
-                .listRowBackground(
-                    logLevelHighlighted
-                        ? Color.accentColor.opacity(0.25)
-                        : Color(.secondarySystemGroupedBackground)
-                )
-            } header: {
-                Text("Logging")
-            } footer: {
-                Text("Controls how verbose the bridge logs are.")
-            }
-
-            Section {
-                Toggle("Log Rotation", isOn: $logRotation)
-                InlineIntField("Directories to Keep", value: $logDirectoriesToKeep, range: 1...50)
-            } header: {
-                Text("Log Files")
-            } footer: {
-                Text("Log rotation deletes old log directories automatically. Adjust how many to keep on disk.")
-            }
-
             Section {
                 Picker("Last Seen Format", selection: $lastSeen) {
                     ForEach(BridgeSettings.LastSeenFormat.allCases, id: \.self) { format in
@@ -134,22 +95,11 @@ struct MainSettingsView: View {
             }
         }
         .discardChangesAlert(hasChanges: hasChanges, isPresented: $showingDiscardAlert) { loadFromStore(); dismiss() }
-        .task { loadFromStore() }
-        .task {
-            // Flash the Log Level row briefly when arriving here from the
-            // Notifications settings link. Matches the transient-highlight
-            // pattern Apple's Settings uses when jumping between panes.
-            guard highlight == .logLevel else { return }
-            try? await Task.sleep(for: .milliseconds(350))
-            withAnimation(.easeInOut(duration: 0.25)) { logLevelHighlighted = true }
-            try? await Task.sleep(for: .milliseconds(900))
-            withAnimation(.easeInOut(duration: 0.6)) { logLevelHighlighted = false }
-        }
+        .reloadOnBridgeInfo(info: environment.store.bridgeInfo, hasChanges: hasChanges, load: loadFromStore)
     }
 
     private func loadFromStore() {
         guard let info = environment.store.bridgeInfo else { return }
-        logLevel = BridgeSettings.LogLevel(rawValue: info.logLevel) ?? .info
         let advanced = info.config?.advanced
         lastSeen = BridgeSettings.LastSeenFormat(rawValue: advanced?.lastSeen ?? "disable") ?? .disabled
         elapsed = advanced?.elapsed ?? false
@@ -158,24 +108,37 @@ struct MainSettingsView: View {
         cacheStateSendOnStartup = advanced?.cacheStateSendOnStartup ?? true
         output = BridgeSettings.OutputFormat(rawValue: advanced?.output ?? "json") ?? .json
         timestampFormat = advanced?.timestampFormat ?? "YYYY-MM-DD HH:mm:ss"
-        logRotation = advanced?.logRotation ?? true
-        logDirectoriesToKeep = advanced?.logDirectoriesToKeep ?? 10
     }
 
     private func applyChanges() {
-        let advanced: [String: JSONValue] = [
-            "log_level": .string(logLevel.rawValue),
-            "last_seen": .string(lastSeen.rawValue),
-            "elapsed": .bool(elapsed),
-            "cache_state": .bool(cacheState),
-            "cache_state_persistent": .bool(cacheStatePersistent),
-            "cache_state_send_on_startup": .bool(cacheStateSendOnStartup),
-            "output": .string(output.rawValue),
-            "timestamp_format": .string(timestampFormat),
-            "log_rotation": .bool(logRotation),
-            "log_directories_to_keep": .int(logDirectoriesToKeep)
-        ]
-        environment.send(topic: Z2MTopics.Request.options, payload: .object(["advanced": .object(advanced)]))
+        guard let info = environment.store.bridgeInfo else { return }
+        let advanced = info.config?.advanced
+        var changes: [String: JSONValue] = [:]
+
+        if lastSeen.rawValue != (advanced?.lastSeen ?? "disable") {
+            changes["last_seen"] = .string(lastSeen.rawValue)
+        }
+        if elapsed != (advanced?.elapsed ?? false) {
+            changes["elapsed"] = .bool(elapsed)
+        }
+        if cacheState != (advanced?.cacheState ?? true) {
+            changes["cache_state"] = .bool(cacheState)
+        }
+        if cacheStatePersistent != (advanced?.cacheStatePersistent ?? true) {
+            changes["cache_state_persistent"] = .bool(cacheStatePersistent)
+        }
+        if cacheStateSendOnStartup != (advanced?.cacheStateSendOnStartup ?? true) {
+            changes["cache_state_send_on_startup"] = .bool(cacheStateSendOnStartup)
+        }
+        if output.rawValue != (advanced?.output ?? "json") {
+            changes["output"] = .string(output.rawValue)
+        }
+        if timestampFormat != (advanced?.timestampFormat ?? "YYYY-MM-DD HH:mm:ss") {
+            changes["timestamp_format"] = .string(timestampFormat)
+        }
+
+        guard !changes.isEmpty else { return }
+        environment.sendBridgeOptions(["advanced": .object(changes)])
     }
 }
 

--- a/Shellbee/Features/Settings/NetworkAccessSettingsView.swift
+++ b/Shellbee/Features/Settings/NetworkAccessSettingsView.swift
@@ -104,7 +104,7 @@ struct NetworkAccessSettingsView: View {
             }
         }
         .discardChangesAlert(hasChanges: hasChanges, isPresented: $showingDiscardAlert) { loadFromStore(); dismiss() }
-        .task { loadFromStore() }
+        .reloadOnBridgeInfo(info: environment.store.bridgeInfo, hasChanges: hasChanges, load: loadFromStore)
     }
 
     private func addPasslistEntry() {
@@ -132,7 +132,7 @@ struct NetworkAccessSettingsView: View {
             "passlist": .array(passlistEntries.map { .string($0) }),
             "blocklist": .array(blocklistEntries.map { .string($0) })
         ]
-        environment.send(topic: Z2MTopics.Request.options, payload: .object(payload))
+        environment.sendBridgeOptions(payload)
     }
 }
 

--- a/Shellbee/Features/Settings/NetworkSettingsView.swift
+++ b/Shellbee/Features/Settings/NetworkSettingsView.swift
@@ -33,13 +33,13 @@ struct NetworkSettingsView: View {
             }
 
             Section {
-                numericField("Transmit Power (dBm)", text: $transmitPower, placeholder: "Default")
-                numericField("Adapter Concurrent (threads)", text: $adapterConcurrent, placeholder: "Default")
-                numericField("Adapter Message Delay (ms)", text: $adapterDelay, placeholder: "Default")
+                numericField("Transmit Power", text: $transmitPower, placeholder: "Default", unit: "dBm")
+                numericField("Concurrency", text: $adapterConcurrent, placeholder: "Default", unit: "threads")
+                numericField("Message Delay", text: $adapterDelay, placeholder: "Default", unit: "ms")
             } header: {
                 Text("Hardware Tuning")
             } footer: {
-                Text("Leave blank to use bridge defaults. Transmit power affects range. Concurrent and delay affect how fast commands are sent to the adapter.")
+                Text("Leave blank to use bridge defaults. Transmit power affects range. Concurrency and message delay affect how fast commands are sent to the adapter.")
             }
         }
         .navigationTitle("Network & Hardware")
@@ -56,15 +56,19 @@ struct NetworkSettingsView: View {
             }
         }
         .discardChangesAlert(hasChanges: hasChanges, isPresented: $showingDiscardAlert) { loadFromStore(); dismiss() }
-        .task { loadFromStore() }
+        .reloadOnBridgeInfo(info: environment.store.bridgeInfo, hasChanges: hasChanges, load: loadFromStore)
     }
 
-    private func numericField(_ label: String, text: Binding<String>, placeholder: String) -> some View {
+    private func numericField(_ label: String, text: Binding<String>, placeholder: String, unit: String) -> some View {
         LabeledContent(label) {
-            TextField(placeholder, text: text)
-                .multilineTextAlignment(.trailing)
-                .keyboardType(.numbersAndPunctuation)
-                .autocorrectionDisabled()
+            HStack(spacing: DesignTokens.Spacing.xs) {
+                TextField(placeholder, text: text)
+                    .multilineTextAlignment(.trailing)
+                    .keyboardType(.numbersAndPunctuation)
+                    .autocorrectionDisabled()
+                Text(unit)
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 
@@ -84,7 +88,7 @@ struct NetworkSettingsView: View {
         if let v = Int(transmitPower) { advanced["transmit_power"] = .int(v) }
         if let v = Int(adapterConcurrent) { advanced["adapter_concurrent"] = .int(v) }
         if let v = Int(adapterDelay) { advanced["adapter_delay"] = .int(v) }
-        environment.send(topic: Z2MTopics.Request.options, payload: .object(["advanced": .object(advanced)]))
+        environment.sendBridgeOptions(["advanced": .object(advanced)])
     }
 }
 

--- a/Shellbee/Features/Settings/OTASettingsView.swift
+++ b/Shellbee/Features/Settings/OTASettingsView.swift
@@ -73,7 +73,7 @@ struct OTASettingsView: View {
             }
         }
         .discardChangesAlert(hasChanges: hasChanges, isPresented: $showingDiscardAlert) { loadFromStore(); dismiss() }
-        .task { loadFromStore() }
+        .reloadOnBridgeInfo(info: environment.store.bridgeInfo, hasChanges: hasChanges, load: loadFromStore)
     }
 
     private func loadFromStore() {
@@ -95,7 +95,7 @@ struct OTASettingsView: View {
             "default_maximum_data_size": .int(defaultMaximumDataSize)
         ]
         if !overrideIndexLocation.isEmpty { ota["zigbee_ota_override_index_location"] = .string(overrideIndexLocation) }
-        environment.send(topic: Z2MTopics.Request.options, payload: .object(["ota": .object(ota)]))
+        environment.sendBridgeOptions(["ota": .object(ota)])
     }
 }
 

--- a/Shellbee/Features/Settings/SerialSettingsView.swift
+++ b/Shellbee/Features/Settings/SerialSettingsView.swift
@@ -83,7 +83,7 @@ struct SerialSettingsView: View {
         } message: {
             Text("Changing adapter settings requires a bridge restart.")
         }
-        .task { loadFromStore() }
+        .reloadOnBridgeInfo(info: environment.store.bridgeInfo, hasChanges: hasChanges, load: loadFromStore)
     }
 
     private func loadFromStore() {
@@ -101,7 +101,7 @@ struct SerialSettingsView: View {
             "baudrate": .int(baudrate)
         ]
         if !adapter.isEmpty { serial["adapter"] = .string(adapter) }
-        environment.send(topic: Z2MTopics.Request.options, payload: .object(["serial": .object(serial)]))
+        environment.sendBridgeOptions(["serial": .object(serial)])
     }
 }
 

--- a/Shellbee/Features/Settings/SettingsView.swift
+++ b/Shellbee/Features/Settings/SettingsView.swift
@@ -79,11 +79,9 @@ struct SettingsView: View {
 
     private var loggingSection: some View {
         Section {
-            NavigationLink { LoggingSettingsView() } label: {
-                settingsLabel(title: "Logging Details", systemImage: "doc.text.magnifyingglass", color: .gray)
+            NavigationLink { LoggingHubView() } label: {
+                settingsLabel(title: "Logging", systemImage: "doc.text.magnifyingglass", color: .gray)
             }
-        } header: {
-            Text("Logging")
         }
     }
 

--- a/Shellbee/Shared/Components/DeviceCard.swift
+++ b/Shellbee/Shared/Components/DeviceCard.swift
@@ -5,13 +5,14 @@ struct DeviceCard: View {
     let state: [String: JSONValue]
     let isAvailable: Bool
     let otaStatus: OTAUpdateStatus?
+    var lastSeenEnabled: Bool = true
     var onRenameTapped: (() -> Void)? = nil
 
     private var isUpdating: Bool { otaStatus?.isActive == true }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            DeviceCardHeader(device: device, state: state, isAvailable: isAvailable, otaStatus: otaStatus, onRenameTapped: onRenameTapped)
+            DeviceCardHeader(device: device, state: state, isAvailable: isAvailable, otaStatus: otaStatus, lastSeenEnabled: lastSeenEnabled, onRenameTapped: onRenameTapped)
                 .padding(DesignTokens.Spacing.lg)
                 .opacity(isUpdating ? 0.75 : 1)
 

--- a/Shellbee/Shared/Components/DeviceCardHeader.swift
+++ b/Shellbee/Shared/Components/DeviceCardHeader.swift
@@ -5,6 +5,10 @@ struct DeviceCardHeader: View {
     let state: [String: JSONValue]
     let isAvailable: Bool
     let otaStatus: OTAUpdateStatus?
+    /// When false, the last-seen label is suppressed entirely — used when
+    /// z2m's `advanced.last_seen` is set to `disable`, since any retained
+    /// value would be stale.
+    var lastSeenEnabled: Bool = true
     var onRenameTapped: (() -> Void)? = nil
 
     var body: some View {
@@ -36,7 +40,7 @@ struct DeviceCardHeader: View {
             }
             .padding(.trailing, DesignTokens.Size.headerLastSeenWidth)
 
-            DeviceCardLastSeen(lastSeen: state.lastSeen)
+            DeviceCardLastSeen(lastSeen: lastSeenEnabled ? state.lastSeen : nil)
                 .frame(width: DesignTokens.Size.headerLastSeenWidth, alignment: .trailing)
                 .offset(y: DesignTokens.Spacing.md)
         }

--- a/Shellbee/Shared/Components/View+ReloadOnBridgeInfo.swift
+++ b/Shellbee/Shared/Components/View+ReloadOnBridgeInfo.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+extension View {
+    /// Runs `load` when the view first appears AND again whenever `value`
+    /// changes — so settings views hydrate correctly even if the underlying
+    /// bridge info arrives after the view has mounted (e.g. on auto-reconnect).
+    /// Skips the reload while the user has unsaved edits.
+    func reloadOnBridgeInfo<V: Equatable>(
+        info value: V,
+        hasChanges: Bool,
+        load: @escaping () -> Void
+    ) -> some View {
+        self
+            .task { load() }
+            .onChange(of: value) { _, _ in
+                if !hasChanges { load() }
+            }
+    }
+}

--- a/ShellbeeTests/Unit/BridgeOptionsPayloadTests.swift
+++ b/ShellbeeTests/Unit/BridgeOptionsPayloadTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import Shellbee
+
+/// Locks in the exact wire shape of `bridge/request/options` so we can rule
+/// out the Swift side when debugging "Invalid payload" errors from z2m.
+final class BridgeOptionsPayloadTests: XCTestCase {
+
+    @MainActor
+    func testElapsedToggleProducesOptionsWrappedAdvancedPayload() throws {
+        let payload: JSONValue = .object([
+            "options": .object([
+                "advanced": .object(["elapsed": .bool(true)])
+            ])
+        ])
+        let envelope = Z2MOutboundEnvelope(topic: "bridge/request/options", payload: payload)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(envelope)
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        XCTAssertEqual(
+            json,
+            #"{"payload":{"options":{"advanced":{"elapsed":true}}},"topic":"bridge\/request\/options"}"#
+        )
+    }
+
+    @MainActor
+    func testRoundTripMatchesZ2MHandlerExpectations() throws {
+        // z2m's bridgeOptions handler requires `typeof message.options === "object"`.
+        // Decode our own wire format the same way z2m would to prove the shape.
+        let payload: JSONValue = .object([
+            "options": .object([
+                "advanced": .object(["last_seen": .string("ISO_8601_local")])
+            ])
+        ])
+        let envelope = Z2MOutboundEnvelope(topic: "bridge/request/options", payload: payload)
+        let data = try JSONEncoder().encode(envelope)
+
+        struct WireEnvelope: Decodable {
+            let topic: String
+            let payload: [String: JSONValue]
+        }
+        let decoded = try JSONDecoder().decode(WireEnvelope.self, from: data)
+
+        XCTAssertEqual(decoded.topic, "bridge/request/options")
+        guard case .object(let inner)? = decoded.payload["options"] else {
+            XCTFail("payload.options must be an object — z2m will reject otherwise")
+            return
+        }
+        guard case .object(let advanced)? = inner["advanced"] else {
+            XCTFail("payload.options.advanced must be an object")
+            return
+        }
+        XCTAssertEqual(advanced["last_seen"], .string("ISO_8601_local"))
+    }
+}


### PR DESCRIPTION
## Summary

- Every `bridge/request/options` send is now wrapped in `{"options": {...}}` via a single `AppEnvironment.sendBridgeOptions` helper. z2m rejected the previous raw form with `Invalid payload`, which made every settings screen look broken. 11 call sites updated.
- Stop overwriting `BridgeInfo.config` with the options response body. z2m's success response only carries `restart_required`; the fresh config arrives on the separate `bridge/info` topic. Decoding the small response into `BridgeConfig` was wiping Server URL and other fields on every Apply and keeping `hasChanges` stuck at `true` immediately after a successful save.
- `BridgeSettings.LogLevel`: rawValue `warn` → `warning` to match z2m's enum. Tolerant parser still accepts `warn` from older servers.
- `log_directories_to_keep` range corrected to 5–1000 per z2m schema.
- General Settings sends only *changed* fields so one stale value can't reject the whole request.
- `device/configure_reporting` now includes the required `endpoint` field (z2m always rejected these before).
- Router surfaces `bridge/response/options`/`…/info` errors as operation errors instead of silently dropping them.
- New `reloadOnBridgeInfo` modifier re-hydrates all 11 settings views when `bridge/info` arrives after the view mounts — fixes blank Settings on auto-reconnect. Skipped while the user has unsaved edits.
- Device cards hide the "Last Seen" label when z2m's `advanced.last_seen` is `disable`, so retained state can't show a misleading stale timestamp.
- Dropped no-op `bridge/request/devices` call from `DeviceBindView` (z2m has no such handler).
- Restructure Logging: new **Settings → Logging** hub with **Basic** (level, rotation, retention) and **Advanced** (outputs, debug filter) pages. **General** trims to Timestamps / State Caching / Output.
- **Network & Hardware**: shorter labels with trailing unit chips so values no longer truncate (`Transmit Power (dB…` → `Transmit Power   Default dBm`).
- **Performance**: units on Concurrent Requests (`requests`) and Device Timeout (`s`).
- Added `BridgeOptionsPayloadTests` that locks in the exact wire shape.

## Test plan

- [x] `xcodebuild build` on iOS 26 simulator
- [x] Unit tests green (`BridgeOptionsPayloadTests`)
- [x] Smoke-tested against a live z2m: toggle Show Elapsed Time, change Log Level, toggle State Caching — all apply without error, values persist, Apply disables afterward, Settings stays populated
- [x] Settings → Logging → Basic: deep-link from Notifications → Bridge Log Level still works and highlights the row
- [x] Device cards: disable `last_seen` in General → Timestamps → last-seen label disappears; enable → label returns
- [x] Settings → Network & Hardware: labels no longer truncate, units appear on the right
- [x] Settings → Performance: units show after Concurrent Requests and Device Timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)