### PR TITLE
Add prepare-release workflow (weekly + on-demand bundle refresh)

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,118 @@
+name: Prepare Release
+
+# Regenerates bundled device docs and images from Koenkk/zigbee2mqtt.io and
+# opens a PR if anything changed. Runs:
+#   1. Weekly on Mondays at 04:00 UTC — keeps bundles fresh between releases.
+#   2. On manual dispatch — run this before tagging a release to pull in any
+#      upstream changes that landed since the last weekly.
+#
+# The actual generation is done by Tools/generate-bundle.swift, which clones
+# the upstream repo, rebuilds the three LZFSE bundles in Shellbee/Resources/,
+# and skips work if nothing upstream changed (--force bypasses the skip).
+#
+# If bundles are unchanged, the job exits quietly without opening a PR.
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why are you running this?'
+        required: false
+        default: 'Pre-release docs refresh'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  refresh-bundles:
+    name: Refresh bundled docs and images
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # We push a new branch from this workflow, so we need a token that
+          # can write to the repo. GITHUB_TOKEN is granted that via the
+          # `permissions` block above.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Select latest Xcode
+        run: |
+          LATEST=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -n1)
+          sudo xcode-select -s "$LATEST"
+          xcodebuild -version
+
+      - name: Regenerate bundles
+        run: |
+          # The script clones Koenkk/zigbee2mqtt.io into the target path if
+          # it doesn't exist, then generates the LZFSE bundles. --force
+          # rebuilds even if the hash file indicates no change.
+          swift Tools/generate-bundle.swift --force /tmp/zigbee2mqtt.io
+
+      - name: Detect changes
+        id: diff
+        run: |
+          if git diff --quiet Shellbee/Resources/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Bundles unchanged — nothing to do."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "## Changes detected" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            git diff --stat Shellbee/Resources/ >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Open PR with refreshed bundles
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          BRANCH="chore/refresh-bundles-${DATE}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+          git add Shellbee/Resources/
+          git commit -m "Refresh bundled docs and images (${DATE})
+
+          Regenerated via Tools/generate-bundle.swift from the latest
+          Koenkk/zigbee2mqtt.io. Auto-opened by prepare-release workflow."
+          git push -u origin "$BRANCH"
+
+          # Use the trigger reason in the PR body when dispatched manually.
+          REASON="${{ github.event.inputs.reason || 'Weekly scheduled refresh' }}"
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Refresh bundled docs and images (${DATE})" \
+            --body "$(cat <<EOF
+          ## Summary
+          Regenerated \`Shellbee/Resources/device_docs.lzfse\`, \`device_images.lzfse\`, and \`device_index.lzfse\` from the latest [Koenkk/zigbee2mqtt.io](https://github.com/Koenkk/zigbee2mqtt.io).
+
+          **Trigger:** ${REASON}
+          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          ## Note on CI
+          PRs opened by \`GITHUB_TOKEN\` do not trigger workflow runs automatically (GitHub security policy to prevent infinite loops). To run Fast CI on this PR, either:
+          - Push an empty commit: \`git commit --allow-empty -m "Trigger CI"\`, or
+          - Close and reopen the PR.
+
+          ## Test plan
+          - [ ] Skim the diff — file sizes should change but not structure
+          - [ ] If you're about to tag a release, merge this first so the release ships current docs
+          EOF
+          )"


### PR DESCRIPTION
## Summary
New workflow `.github/workflows/prepare-release.yml` that regenerates the LZFSE docs/images bundles from [Koenkk/zigbee2mqtt.io](https://github.com/Koenkk/zigbee2mqtt.io) and opens a PR when they change.

## Triggers
- Weekly cron — Mondays at 04:00 UTC
- Manual dispatch from the Actions tab (run this before tagging a release)

## How
Runs `Tools/generate-bundle.swift --force /tmp/zigbee2mqtt.io` on a macOS runner, diffs `Shellbee/Resources/`, and opens a PR if anything changed. Exits quietly when upstream hasn't moved.

## Scope
`.github/workflows/prepare-release.yml` only.

## Release notes
n/a — infra.