### PR TITLE
Release: issue templates, optimistic flows, seeder health, CI fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: Bug report
+description: Something in Shellbee is broken or behaving unexpectedly.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. The more concrete you can be, the faster it gets fixed.
+        If you can reproduce it against the mock bridge (`docker-compose up` in this repo), please mention that — it's the fastest path to a fix.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, and what did Shellbee do instead?
+      placeholder: |
+        1. Opened the Bedroom Light card
+        2. Tapped the brightness slider
+        3. Expected: brightness changes
+        4. Actual: card freezes for ~5s, then snaps back to old value
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps so I can hit the same bug. If it's intermittent, say roughly how often.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: shellbee-version
+    attributes:
+      label: Shellbee version
+      description: Settings → About, or the App Store version. Include the build number if you have it.
+      placeholder: "1.2.0 (45)"
+    validations:
+      required: true
+
+  - type: input
+    id: ios-version
+    attributes:
+      label: iOS / iPadOS version and device
+      placeholder: "iOS 18.2, iPhone 15 Pro"
+    validations:
+      required: true
+
+  - type: input
+    id: z2m-version
+    attributes:
+      label: Zigbee2MQTT version
+      description: Found in the Z2M web frontend under Settings → About, or in `bridge/info`.
+      placeholder: "2.1.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: bridge-type
+    attributes:
+      label: Bridge connection
+      options:
+        - Real Z2M bridge over WebSocket
+        - Mock bridge from this repo (docker-compose)
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: device-info
+    attributes:
+      label: Affected device(s)
+      description: If the bug is about a specific Zigbee device, paste its model and manufacturer (visible on the device card or in `bridge/devices`). Skip if not device-specific.
+      placeholder: "Philips Hue White A60 (LWA001), Signify Netherlands B.V."
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: |
+        Drag in screenshots, a screen recording, or relevant log lines from Settings → Logging. Redact any auth tokens or hostnames you don't want public.
+      placeholder: "Paste logs here or drop in a screenshot."
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this isn't a duplicate.
+          required: true
+        - label: I'm on the latest version of Shellbee available to me.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/tashda/Shellbee/discussions
+    about: Ask a question or discuss an idea before filing a feature request.
+  - name: Privacy policy
+    url: https://github.com/tashda/Shellbee/blob/main/PRIVACY.md
+    about: How Shellbee handles your data.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Suggest a new feature, setting, or improvement.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Shellbee aims to feel familiar to Z2M web frontend users, so if your idea exists there already, pointing at it (screenshot or link) is the most useful thing you can do.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do today, and where does Shellbee get in the way?
+      placeholder: "I want to ... but currently I have to ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like Shellbee to do?
+      description: Describe the feature or change. UI sketches, screenshots from the Z2M web frontend, or "it should look like X screen but with Y" all work.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: z2m-parity
+    attributes:
+      label: Does the Z2M web frontend already do this?
+      options:
+        - Yes — and Shellbee should match it
+        - Partially — Z2M does something similar
+        - No — this would be Shellbee-specific
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+      description: Workarounds you're using today, or other approaches you thought about. Skip if there aren't any.
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and discussions and this isn't already requested.
+          required: true

--- a/docker/seeder/control.py
+++ b/docker/seeder/control.py
@@ -43,7 +43,15 @@ app = FastAPI(title="Shellbee Test Center", docs_url="/api/docs", redoc_url=None
 def _client():
     c = seeder._client
     if c is None:
-        raise HTTPException(503, "MQTT client not connected yet")
+        raise HTTPException(503, "Seeder has not initialised the MQTT client yet")
+    if not getattr(seeder, "_mqtt_connected", False):
+        last = getattr(seeder, "_mqtt_last_error", None) or "no on_connect callback received"
+        raise HTTPException(
+            503,
+            f"MQTT broker not connected (host={seeder.MQTT_HOST}:{seeder.MQTT_PORT}, last_error={last})",
+        )
+    if not getattr(seeder, "_seed_complete", False):
+        raise HTTPException(503, "Seeder still waiting for bridge/state online — initial seed not yet published")
     return c
 
 
@@ -59,6 +67,22 @@ def _ok(**extra: Any) -> dict:
 
 
 # ── Read APIs ─────────────────────────────────────────────────────────────
+
+@app.get("/api/health")
+def get_health():
+    return {
+        "mqtt": {
+            "host": seeder.MQTT_HOST,
+            "port": seeder.MQTT_PORT,
+            "client_initialised": seeder._client is not None,
+            "connected": getattr(seeder, "_mqtt_connected", False),
+            "last_error": getattr(seeder, "_mqtt_last_error", None),
+        },
+        "z2m_online": getattr(seeder, "_z2m_online", False),
+        "seed_complete": getattr(seeder, "_seed_complete", False),
+        "z2m_topic": seeder.Z2M_TOPIC,
+    }
+
 
 @app.get("/api/state")
 def get_state():

--- a/docker/seeder/seeder.py
+++ b/docker/seeder/seeder.py
@@ -783,16 +783,28 @@ def handle_request(client, subpath: str, payload: Any) -> None:
 # ── MQTT wiring ────────────────────────────────────────────────────────────
 
 _z2m_online = False
-_client: mqtt.Client | None = None  # set in main() once connected; used by control.py
+_client: mqtt.Client | None = None  # set in main() once instantiated; used by control.py
+_mqtt_connected = False              # True between on_connect and on_disconnect
+_mqtt_last_error: str | None = None  # last broker connect/disconnect failure reason
+_seed_complete = False               # True after seed_initial() finishes
 
 
 def on_connect(client, userdata, flags, reason_code, properties):
+    global _mqtt_connected, _mqtt_last_error
     log.info("Connected to MQTT broker (rc=%s)", reason_code)
+    _mqtt_connected = True
+    _mqtt_last_error = None
     client.subscribe(f"{Z2M_TOPIC}/bridge/state")
     client.subscribe(f"{Z2M_TOPIC}/+/set")
     client.subscribe(f"{Z2M_TOPIC}/+/get")
     client.subscribe(f"{Z2M_TOPIC}/bridge/request/#")
     client.subscribe(f"{Z2M_TOPIC}/_engine/client_connected")
+
+
+def on_disconnect(client, userdata, *args):
+    global _mqtt_connected
+    _mqtt_connected = False
+    log.warning("Disconnected from MQTT broker (args=%s)", args)
 
 
 def on_message(client, userdata, msg):
@@ -912,20 +924,32 @@ def drift_tick(client) -> None:
 # ── Main ───────────────────────────────────────────────────────────────────
 
 def main() -> None:
-    global _client
+    global _client, _mqtt_last_error, _seed_complete
     _init_state()
 
     client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
     client.on_connect = on_connect
+    client.on_disconnect = on_disconnect
     client.on_message = on_message
     _client = client
+
+    # Start the test-center HTTP server before we touch the broker. If MQTT is
+    # unreachable, scenarios will still 503 — but /api/state and /api/health
+    # come up immediately so the operator can see what's wrong.
+    try:
+        import control
+        control.start_in_thread()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("Control plane not started: %s", exc)
 
     log.info("Connecting to %s:%d …", MQTT_HOST, MQTT_PORT)
     while True:
         try:
             client.connect(MQTT_HOST, MQTT_PORT, keepalive=60)
+            _mqtt_last_error = None
             break
         except Exception as exc:
+            _mqtt_last_error = f"{type(exc).__name__}: {exc}"
             log.warning("Broker not ready (%s), retrying in 3s …", exc)
             time.sleep(3)
 
@@ -941,14 +965,7 @@ def main() -> None:
 
     time.sleep(2)
     seed_initial(client)
-
-    # HTTP control plane (test center). Imported lazily so a missing FastAPI
-    # install does not block the core MQTT engine from running.
-    try:
-        import control
-        control.start_in_thread()
-    except Exception as exc:  # noqa: BLE001
-        log.warning("Control plane not started: %s", exc)
+    _seed_complete = True
 
     if MODE == "once":
         client.loop_stop()


### PR DESCRIPTION
## Summary

Bundles the work that has accumulated on \`dev\` since v1.2.0:

- **GitHub issue templates** — adds \`bug_report.yml\`, \`feature_request.yml\`, and \`config.yml\` under \`.github/ISSUE_TEMPLATE/\` so the *New issue* page stops dropping users straight into a blank form.
- **Seeder MQTT diagnostics** — new \`/api/health\` endpoint and clearer 503 messages on the test-center control plane; surfaces broker connection state and seed completion so failed scenarios are debuggable without reading logs.
- **Device flows** — optimistic device rename, optimistic remove with Deleting badge, Recently Added section, interview indicator, fix for device detail title not updating after rename.
- **Mock bridge** — native macOS launcher (drops Docker on Full CI), HTTP test center for scenario-driven testing.
- **CI** — Full CI workflow stabilization (parallelism tuning, simctl bootstatus, cancel-on-failure), Prepare Release PR step fix, drop UI tests from Full CI during redesign.
- **UI** — Fan card redesign, Permit Join active sheet redesign, Settings Logging restructure.

## Test plan

- [ ] Fast CI passes on PR
- [ ] After merge, confirm GitHub *New issue* page shows the bug / feature templates
- [ ] Spin up mock bridge and hit \`GET /api/health\` to verify diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)