### PR TITLE
v1.5.1: Xcode Cloud signing config

### DIFF
--- a/Shellbee.xcodeproj/project.pbxproj
+++ b/Shellbee.xcodeproj/project.pbxproj
@@ -830,7 +830,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -871,7 +871,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -911,7 +911,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_WIDGET_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -953,7 +953,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_WIDGET_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Xcode Cloud runs this after cloning the repo, before xcodebuild.
+# Generates Config/BuildSettings.local.xcconfig from environment variables
+# defined in the Xcode Cloud workflow, since the real local xcconfig is
+# gitignored and not available on Apple's runners.
+#
+# Required env vars (set in Xcode Cloud workflow → Environment Variables):
+#   APP_BUNDLE_ID            e.g. com.tashda.shellbee
+#   APP_DEVELOPMENT_TEAM     e.g. JQU2HR44D8 (mark as secret)
+#   APP_WIDGET_BUNDLE_SUFFIX e.g. widgets
+#
+# Optional (omit unless you want Sentry symbol upload from CI):
+#   SENTRY_DSN, SENTRY_ORG, SENTRY_PROJECT, SENTRY_AUTH_TOKEN
+
+set -eu
+
+if [ -z "${APP_BUNDLE_ID:-}" ] || [ -z "${APP_DEVELOPMENT_TEAM:-}" ] || [ -z "${APP_WIDGET_BUNDLE_SUFFIX:-}" ]; then
+  echo "ci_post_clone.sh: required env vars not set (APP_BUNDLE_ID, APP_DEVELOPMENT_TEAM, APP_WIDGET_BUNDLE_SUFFIX)"
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET="$REPO_ROOT/Config/BuildSettings.local.xcconfig"
+
+{
+  echo "APP_DEVELOPMENT_TEAM = $APP_DEVELOPMENT_TEAM"
+  echo "APP_BUNDLE_ID = $APP_BUNDLE_ID"
+  echo "APP_WIDGET_BUNDLE_SUFFIX = $APP_WIDGET_BUNDLE_SUFFIX"
+  echo "APP_WIDGET_BUNDLE_ID = \$(APP_BUNDLE_ID).\$(APP_WIDGET_BUNDLE_SUFFIX)"
+  echo "APP_TESTS_BUNDLE_ID = \$(APP_BUNDLE_ID).tests"
+  echo "APP_UI_TESTS_BUNDLE_ID = \$(APP_BUNDLE_ID).uitests"
+  [ -n "${SENTRY_DSN:-}" ]          && echo "SENTRY_DSN = $SENTRY_DSN"
+  [ -n "${SENTRY_ORG:-}" ]          && echo "SENTRY_ORG = $SENTRY_ORG"
+  [ -n "${SENTRY_PROJECT:-}" ]      && echo "SENTRY_PROJECT = $SENTRY_PROJECT"
+  [ -n "${SENTRY_AUTH_TOKEN:-}" ]   && echo "SENTRY_AUTH_TOKEN = $SENTRY_AUTH_TOKEN"
+} > "$TARGET"
+
+echo "ci_post_clone.sh: wrote $TARGET"

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -5,17 +5,21 @@
 # gitignored and not available on Apple's runners.
 #
 # Required env vars (set in Xcode Cloud workflow → Environment Variables):
-#   APP_BUNDLE_ID            e.g. com.tashda.shellbee
-#   APP_DEVELOPMENT_TEAM     e.g. JQU2HR44D8 (mark as secret)
-#   APP_WIDGET_BUNDLE_SUFFIX e.g. widgets
+#   SHELLBEE_BUNDLE_ID       e.g. com.tashda.shellbee
+#   SHELLBEE_TEAM_ID         e.g. JQU2HR44D8 (mark as secret)
+#   SHELLBEE_WIDGET_SUFFIX   e.g. widgets
+#
+# These are intentionally renamed (vs. APP_BUNDLE_ID / APP_DEVELOPMENT_TEAM) to
+# avoid Xcode Cloud rejecting names that collide with reserved Xcode build
+# settings like DEVELOPMENT_TEAM.
 #
 # Optional (omit unless you want Sentry symbol upload from CI):
 #   SENTRY_DSN, SENTRY_ORG, SENTRY_PROJECT, SENTRY_AUTH_TOKEN
 
 set -eu
 
-if [ -z "${APP_BUNDLE_ID:-}" ] || [ -z "${APP_DEVELOPMENT_TEAM:-}" ] || [ -z "${APP_WIDGET_BUNDLE_SUFFIX:-}" ]; then
-  echo "ci_post_clone.sh: required env vars not set (APP_BUNDLE_ID, APP_DEVELOPMENT_TEAM, APP_WIDGET_BUNDLE_SUFFIX)"
+if [ -z "${SHELLBEE_BUNDLE_ID:-}" ] || [ -z "${SHELLBEE_TEAM_ID:-}" ] || [ -z "${SHELLBEE_WIDGET_SUFFIX:-}" ]; then
+  echo "ci_post_clone.sh: required env vars not set (SHELLBEE_BUNDLE_ID, SHELLBEE_TEAM_ID, SHELLBEE_WIDGET_SUFFIX)"
   exit 1
 fi
 
@@ -23,9 +27,9 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TARGET="$REPO_ROOT/Config/BuildSettings.local.xcconfig"
 
 {
-  echo "APP_DEVELOPMENT_TEAM = $APP_DEVELOPMENT_TEAM"
-  echo "APP_BUNDLE_ID = $APP_BUNDLE_ID"
-  echo "APP_WIDGET_BUNDLE_SUFFIX = $APP_WIDGET_BUNDLE_SUFFIX"
+  echo "APP_DEVELOPMENT_TEAM = $SHELLBEE_TEAM_ID"
+  echo "APP_BUNDLE_ID = $SHELLBEE_BUNDLE_ID"
+  echo "APP_WIDGET_BUNDLE_SUFFIX = $SHELLBEE_WIDGET_SUFFIX"
   echo "APP_WIDGET_BUNDLE_ID = \$(APP_BUNDLE_ID).\$(APP_WIDGET_BUNDLE_SUFFIX)"
   echo "APP_TESTS_BUNDLE_ID = \$(APP_BUNDLE_ID).tests"
   echo "APP_UI_TESTS_BUNDLE_ID = \$(APP_BUNDLE_ID).uitests"


### PR DESCRIPTION
## Summary
- Add `ci_scripts/ci_post_clone.sh` so Xcode Cloud regenerates `Config/BuildSettings.local.xcconfig` from workflow env vars (the file is gitignored and not available on Apple's runners).
- Bump `MARKETING_VERSION` to 1.5.1 to ship this through the tag-triggered release pipeline.

Required Xcode Cloud env vars (already configured): `SHELLBEE_BUNDLE_ID`, `SHELLBEE_TEAM_ID`, `SHELLBEE_WIDGET_SUFFIX`. Names are renamed from `APP_*` because Xcode Cloud rejects env var names that collide with reserved Xcode build settings (e.g. `DEVELOPMENT_TEAM`).

## Test plan
- [ ] Tag push triggers GitHub Release workflow — release published.
- [ ] Tag push triggers Xcode Cloud "Release on tag" — archive succeeds, signs with distribution cert.
- [ ] Build appears in App Store Connect → TestFlight as 1.5.1, available to internal testers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)