### PR TITLE
Release v1.5.3: restore Logs swipe gesture

### DIFF
--- a/Shellbee.xcodeproj/project.pbxproj
+++ b/Shellbee.xcodeproj/project.pbxproj
@@ -856,9 +856,11 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = Shellbee.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "$(APP_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = JQU2HR44D8;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Config/Info.plist;
@@ -872,6 +874,8 @@
 				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Shellbee App Store";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -933,9 +937,11 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = ShellbeeWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "$(APP_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = JQU2HR44D8;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShellbeeWidgets/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Shellbee Widgets";
@@ -950,6 +956,8 @@
 				MARKETING_VERSION = 1.5.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_WIDGET_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Shellbee Widgets App Store";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Shellbee.xcodeproj/project.pbxproj
+++ b/Shellbee.xcodeproj/project.pbxproj
@@ -830,7 +830,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.2;
+				MARKETING_VERSION = 1.5.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -871,7 +871,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.2;
+				MARKETING_VERSION = 1.5.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -911,7 +911,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.2;
+				MARKETING_VERSION = 1.5.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_WIDGET_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -953,7 +953,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.2;
+				MARKETING_VERSION = 1.5.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_WIDGET_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Shellbee/Features/Logs/LogsView.swift
+++ b/Shellbee/Features/Logs/LogsView.swift
@@ -82,11 +82,25 @@ struct LogsView: View {
 
     @ViewBuilder
     private var modeContent: some View {
-        switch mode {
-        case .activity:
-            ActivityLogContent(viewModel: activityVM)
-        case .log:
-            BridgeLogView(viewModel: bridgeVM)
+        let position = Binding<LogMode?>(
+            get: { mode },
+            set: { if let new = $0, new != mode { mode = new } }
+        )
+        GeometryReader { geo in
+            ScrollView(.horizontal) {
+                LazyHStack(spacing: 0) {
+                    ActivityLogContent(viewModel: activityVM)
+                        .frame(width: geo.size.width, height: geo.size.height)
+                        .id(LogMode.activity)
+                    BridgeLogView(viewModel: bridgeVM)
+                        .frame(width: geo.size.width, height: geo.size.height)
+                        .id(LogMode.log)
+                }
+                .scrollTargetLayout()
+            }
+            .scrollTargetBehavior(.paging)
+            .scrollIndicators(.hidden)
+            .scrollPosition(id: position)
         }
     }
 


### PR DESCRIPTION
## Summary

- Restore native horizontal swipe between **Activity** and **Log** on the Logs page, lost in the v1.5.0 redesign.
- Use `ScrollView(.horizontal) + .scrollTargetBehavior(.paging) + .scrollPosition(id:)` so the toolbar stays transparent (blurs on scroll) and there's no bottom seam — both regressions that the original `TabView(.page)` introduced once the tab bar was hidden.
- Sized via `GeometryReader` so the inner `List` respects the nav bar's safe-area inset.

Closes #60

## Test plan

- [x] Open Logs from Home → Show All
- [x] Toolbar transparent at top of list, blurs on scroll
- [x] No white seam at the bottom
- [x] Tab bar hidden on Logs
- [x] Swipe left/right between Activity and Log feels native (finger-tracking)
- [x] Tapping the segmented picker animates the swap
- [x] First row visible (not under the toolbar blur)