### PR TITLE
Retry flaky Z2MIntegrationTests once on Full CI

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -131,6 +131,12 @@ jobs:
           # (keychain/concurrency issues that only fail on GitHub runners) —
           # except Z2MIntegrationTests, which Full CI explicitly runs because
           # we now have the mock bridge up. See xctestplans/README.md.
+          # Z2MIntegrationTests talks to the live mock bridge over a real
+          # WebSocket. On GitHub's shared runners, back-to-back tests
+          # occasionally race the previous client's teardown against the
+          # bridge replaying ~173 retained messages, causing a connect
+          # timeout. Retry once per test on failure to absorb that flake
+          # without masking real regressions — a true bug will fail twice.
           set -o pipefail
           xcodebuild test-without-building \
             -project Shellbee.xcodeproj -scheme "$SCHEME" \
@@ -143,6 +149,7 @@ jobs:
             -skip-testing:"ShellbeeTests/NotificationPreferencesTests" \
             -skip-testing:"ShellbeeTests/ConnectionConfigTests/testSecondLoadAfterLegacyMigrationStillReturnsToken" \
             -skip-testing:"ShellbeeTests/Z2MIntegrationTests/testReloadedPersistedConfigConnectsAndReceivesBridgeInfo" \
+            -retry-tests-on-failure -test-iterations 2 \
             -resultBundlePath "$DERIVED_DATA/UnitTests.xcresult" \
             CODE_SIGNING_ALLOWED=NO | tee test-unit.log
 


### PR DESCRIPTION
## Summary
- Nightly Full CI has been red most of the last two weeks. The April 25–May 4 streak was a real test/bridge contract bug fixed in v1.6.0 (`6a25a9d`). Last night (May 6) failed on a different, genuinely flaky test: `testReceivesBridgeDevices` timed out at `client.connect(url:)` for 18.9 s. The mock bridge replays ~173 retained messages on every new WS client, and back-to-back integration tests occasionally race the previous client's teardown on the shared GitHub runner.
- Add `-retry-tests-on-failure -test-iterations 2` to the unit+integration xcodebuild step so a one-off flake gets a single retry. Genuine regressions still fail twice in a row and surface red.
- Workflow-only change, no app code touched.

## Test plan
- [ ] Manually dispatch `CI (Full)` from the Actions tab on `main` after merge and confirm the unit+integration job is green.
- [ ] Watch tomorrow's scheduled 03:00 UTC run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)