### PR TITLE
Stabilize Full CI and automate bundle refreshes

### DIFF
--- a/.github/scripts/start-mock-bridge.sh
+++ b/.github/scripts/start-mock-bridge.sh
@@ -82,7 +82,8 @@ echo "==> [primary] Starting seeder"
 (
   cd "$REPO_ROOT/docker/seeder"
   MQTT_HOST=localhost MQTT_PORT=1883 Z2M_TOPIC=zigbee2mqtt \
-  MODE=continuous SEED_INTERVAL=10 \
+  MODE=continuous SEED_INTERVAL="${MOCK_SEED_INTERVAL:-10}" \
+  DRIFT_ON_CLIENT_CONNECT="${DRIFT_ON_CLIENT_CONNECT:-1}" \
   nohup "$PYTHON" -u seeder.py >"$LOG_DIR/z2m-seeder.log" 2>&1 &
   echo $! > "$LOG_DIR/z2m-seeder.pid"
 )
@@ -117,7 +118,8 @@ if [[ "$DUAL" == "1" ]]; then
   (
     cd "$REPO_ROOT/docker/seeder"
     MQTT_HOST=localhost MQTT_PORT=1884 Z2M_TOPIC=zigbee2mqtt \
-    MODE=continuous SEED_INTERVAL=10 FIXTURE_PREFIX=Lab \
+    MODE=continuous SEED_INTERVAL="${MOCK_SEED_INTERVAL:-10}" \
+    DRIFT_ON_CLIENT_CONNECT="${DRIFT_ON_CLIENT_CONNECT:-1}" FIXTURE_PREFIX=Lab \
     nohup "$PYTHON" -u seeder.py >"$LOG_DIR/z2m-seeder-2.log" 2>&1 &
     echo $! > "$LOG_DIR/z2m-seeder-2.pid"
   )

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -7,6 +7,12 @@ name: CI (Fast)
 # Typical duration: 5-8 min.
 
 on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why are you running Fast CI?'
+        required: false
+        default: 'Manual run'
   pull_request:
     branches: [main]
     paths-ignore:

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -72,6 +72,11 @@ jobs:
       - name: Start dual mock Z2M bridges (native)
         env:
           MULTI_BRIDGE: "1"
+          # The integration tests open one connection each. Replaying retained
+          # state is sufficient; a 173-device drift burst per connection only
+          # overloads the bridge and makes first-frame timing nondeterministic.
+          DRIFT_ON_CLIENT_CONNECT: "0"
+          MOCK_SEED_INTERVAL: "60"
         run: ./.github/scripts/start-mock-bridge.sh
 
       - name: Select latest Xcode
@@ -368,4 +373,3 @@ jobs:
             ${{ env.DERIVED_DATA }}/UITests.xcresult
           if-no-files-found: ignore
           retention-days: 14
-

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,7 +1,7 @@
 name: Prepare Release
 
 # Regenerates bundled device docs and images from Koenkk/zigbee2mqtt.io and
-# opens a PR if anything changed. Runs:
+# opens, validates, and merges a PR if anything changed. Runs:
 #   1. Weekly on Mondays at 04:00 UTC — keeps bundles fresh between releases.
 #   2. On manual dispatch — run this before tagging a release to pull in any
 #      upstream changes that landed since the last weekly.
@@ -11,6 +11,8 @@ name: Prepare Release
 # and skips work if nothing upstream changed (--force bypasses the skip).
 #
 # If bundles are unchanged, the job exits quietly without opening a PR.
+# Refresh PRs run Fast CI through workflow_dispatch because GitHub suppresses
+# pull_request workflows for PRs created with GITHUB_TOKEN.
 
 on:
   schedule:
@@ -23,6 +25,7 @@ on:
         default: 'Pre-release docs refresh'
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -34,7 +37,7 @@ jobs:
   refresh-bundles:
     name: Refresh bundled docs and images
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -74,6 +77,7 @@ jobs:
           fi
 
       - name: Open PR with refreshed bundles
+        id: pr
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -108,10 +112,8 @@ jobs:
           **Trigger:** __REASON__
           **Run:** __RUN_URL__
 
-          ## Note on CI
-          PRs opened by `GITHUB_TOKEN` do not trigger workflow runs automatically (GitHub security policy to prevent infinite loops). To run Fast CI on this PR, either:
-          - Push an empty commit: `git commit --allow-empty -m "Trigger CI"`, or
-          - Close and reopen the PR.
+          ## Automation
+          Fast CI is dispatched for this commit. The workflow squash-merges this PR automatically after CI succeeds.
 
           ## Test plan
           - [ ] Skim the diff — file sizes should change but not structure
@@ -121,8 +123,60 @@ jobs:
           # Inject runtime values without going through shell-quote hell.
           sed -i '' -e "s|__REASON__|${REASON}|" -e "s|__RUN_URL__|${RUN_URL}|" /tmp/pr-body.md
 
-          gh pr create \
+          PR_URL=$(gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "Refresh bundled docs and images (${DATE})" \
-            --body-file /tmp/pr-body.md
+            --body-file /tmp/pr-body.md)
+
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "number=${PR_URL##*/}" >> "$GITHUB_OUTPUT"
+          echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch Fast CI
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.pr.outputs.branch }}
+        run: |
+          gh workflow run ci-fast.yml \
+            --ref "$BRANCH" \
+            -f reason="Validate automatic bundle refresh"
+
+      - name: Wait for Fast CI
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.pr.outputs.branch }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          RUN_ID=""
+          for attempt in $(seq 1 30); do
+            RUN_ID=$(gh run list \
+              --workflow=ci-fast.yml \
+              --branch "$BRANCH" \
+              --event workflow_dispatch \
+              --limit 20 \
+              --json databaseId,headSha \
+              --jq ".[] | select(.headSha == \"$HEAD_SHA\") | .databaseId" \
+              | head -n1)
+            if [ -n "$RUN_ID" ]; then
+              break
+            fi
+            sleep 2
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "Fast CI run was not created for $HEAD_SHA" >&2
+            exit 1
+          fi
+
+          gh run watch "$RUN_ID" --exit-status --interval 10
+
+      - name: Squash-merge refreshed bundles
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr merge "$PR_NUMBER" --squash --delete-branch

--- a/Shellbee.xcodeproj/xcshareddata/xctestplans/README.md
+++ b/Shellbee.xcodeproj/xcshareddata/xctestplans/README.md
@@ -18,10 +18,12 @@ Keychain, etc.). Used by `ci-fast.yml` to gate PRs.
 `ci-full.yml` uses the default `Shellbee.xctestplan` but mirrors the same
 skip set on the `xcodebuild` command line via `-skip-testing` flags — the
 same root causes apply on Full CI too because it's the same runner image.
-The exception is `Z2MIntegrationTests`, which Full CI runs because it starts
-the mock z2m bridge first (one method that hits the keychain still has to
-be skipped — see the table below). If you add or remove a skip in this plan,
-mirror the change in `.github/workflows/ci-full.yml`.
+The exceptions are `Z2MIntegrationTests` and `MultiBridgeIntegrationTests`,
+which Full CI runs because it starts the dual mock z2m bridge first (one method
+that hits the keychain still has to be skipped — see the table below). If you
+add or remove a skip in this plan, mirror the change in
+`.github/workflows/ci-full.yml` when the same runner limitation also applies
+to Full CI.
 
 Every entry in `skippedTests` is tech debt with a tracking reason. When the
 underlying problem is fixed, the skip entry should be removed in the same PR
@@ -32,6 +34,7 @@ as the fix.
 | Test | Reason |
 |---|---|
 | `Z2MIntegrationTests` (entire class) | Requires the docker z2m bridge on `localhost:8080`, which Fast CI does not start. Runs in Full CI instead. |
+| `MultiBridgeIntegrationTests` (entire class) | Requires both mock bridges on `localhost:8080` and `localhost:8082`, which Fast CI does not start. Runs in Full CI instead. |
 | `ConnectionConfigTests/testSaveAndLoad()` | Reads a token from the Keychain that was just written. iOS simulator on GitHub runners has no provisioning profile, so `SecItem*` silently no-ops; the load returns nil. Fix: abstract the Keychain read/write so tests can inject an in-memory store. |
 | `ConnectionConfigTests/testSecondLoadAfterLegacyMigrationStillReturnsToken()` | Same Keychain limitation. |
 | `ConnectionHistoryTests` (entire class) | Every test calls `h.add(...)` → `save()` → `persistToken(for:)` which hits the Keychain. Without a provisioning profile, the GitHub runner crashes (malloc free corruption) inside `SecItem*` rather than returning a no-op error. Skip the whole class until the Keychain layer is abstracted (same root cause as the two `ConnectionConfigTests` skips). |

--- a/Shellbee.xcodeproj/xcshareddata/xctestplans/Shellbee-CI.xctestplan
+++ b/Shellbee.xcodeproj/xcshareddata/xctestplans/Shellbee-CI.xctestplan
@@ -26,6 +26,7 @@
         "ConnectionConfigTests\/testSecondLoadAfterLegacyMigrationStillReturnsToken()",
         "ConnectionHistoryTests",
         "HomeLayoutStoreTests",
+        "MultiBridgeIntegrationTests",
         "NotificationPreferencesTests",
         "Z2MIntegrationTests"
       ],

--- a/ShellbeeTests/Integration/MockBridgeProbe.swift
+++ b/ShellbeeTests/Integration/MockBridgeProbe.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Network
+
+enum MockBridgeProbe {
+    static func isReachable(
+        host: String,
+        port: Int,
+        timeout: TimeInterval = 3
+    ) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let connection = NWConnection(
+                host: NWEndpoint.Host(host),
+                port: NWEndpoint.Port(integerLiteral: UInt16(port)),
+                using: .tcp
+            )
+            let gate = ResumeGate()
+            let finish: @Sendable (Bool) -> Void = { value in
+                guard gate.claim() else { return }
+                connection.cancel()
+                continuation.resume(returning: value)
+            }
+
+            let timer = DispatchSource.makeTimerSource(queue: .global())
+            timer.schedule(deadline: .now() + timeout)
+            timer.setEventHandler {
+                timer.cancel()
+                finish(false)
+            }
+            timer.resume()
+
+            connection.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    timer.cancel()
+                    finish(true)
+                case .failed, .cancelled:
+                    timer.cancel()
+                    finish(false)
+                default:
+                    break
+                }
+            }
+            connection.start(queue: .global())
+        }
+    }
+}
+
+enum RequiredMockBridgeError: LocalizedError {
+    case unavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable(let message): message
+        }
+    }
+}
+
+private final class ResumeGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var claimed = false
+
+    func claim() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !claimed else { return false }
+        claimed = true
+        return true
+    }
+}

--- a/ShellbeeTests/Integration/MultiBridgeIntegrationTests.swift
+++ b/ShellbeeTests/Integration/MultiBridgeIntegrationTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import Network
 @testable import Shellbee
 
 /// Integration tests that connect to TWO real Z2M instances concurrently
@@ -147,61 +146,18 @@ final class MultiBridgeIntegrationTests: XCTestCase, @unchecked Sendable {
         async let s = ping(host: Self.secondaryHost, port: Self.secondaryPort)
         let (primaryUp, secondaryUp) = await (p, s)
         guard primaryUp, secondaryUp else {
-            throw XCTSkip("""
+            let message = """
             Dual-bridge mock stack not running. Start with:
               docker compose up -d
             or on GitHub Actions:
               MULTI_BRIDGE=1 ./.github/scripts/start-mock-bridge.sh
             primary=\(primaryUp ? "up" : "down") secondary=\(secondaryUp ? "up" : "down")
-            """)
+            """
+            throw RequiredMockBridgeError.unavailable(message)
         }
     }
 
     private func ping(host: String, port: Int) async -> Bool {
-        await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
-            let conn = NWConnection(host: NWEndpoint.Host(host),
-                                    port: NWEndpoint.Port(integerLiteral: UInt16(port)),
-                                    using: .tcp)
-            let resumed = ManagedAtomicBool(false)
-            let resumeOnce: @Sendable (Bool) -> Void = { value in
-                if resumed.compareExchange(expected: false, desired: true) {
-                    cont.resume(returning: value)
-                }
-            }
-            let timer = DispatchSource.makeTimerSource(queue: .global())
-            timer.schedule(deadline: .now() + 3)
-            timer.setEventHandler {
-                conn.cancel()
-                timer.cancel()
-                resumeOnce(false)
-            }
-            timer.resume()
-            conn.stateUpdateHandler = { state in
-                switch state {
-                case .ready:
-                    timer.cancel()
-                    conn.cancel()
-                    resumeOnce(true)
-                case .failed, .cancelled:
-                    timer.cancel()
-                    resumeOnce(false)
-                default: break
-                }
-            }
-            conn.start(queue: .global())
-        }
-    }
-}
-
-/// Tiny atomic-bool wrapper used to guard `cont.resume` so the timer + state
-/// callbacks can race without double-resuming the continuation.
-private final class ManagedAtomicBool: @unchecked Sendable {
-    private let lock = NSLock()
-    private var value: Bool
-    init(_ initial: Bool) { value = initial }
-    func compareExchange(expected: Bool, desired: Bool) -> Bool {
-        lock.lock(); defer { lock.unlock() }
-        if value == expected { value = desired; return true }
-        return false
+        await MockBridgeProbe.isReachable(host: host, port: port)
     }
 }

--- a/ShellbeeTests/Integration/Z2MIntegrationTests.swift
+++ b/ShellbeeTests/Integration/Z2MIntegrationTests.swift
@@ -6,7 +6,7 @@ import XCTest
 /// To run: start the Docker stack first:
 ///   docker compose up -d
 ///
-/// If Z2M is not reachable on localhost:8080, all tests are skipped automatically.
+/// The selected integration suite fails if Z2M is not reachable on localhost:8080.
 final class Z2MIntegrationTests: XCTestCase, @unchecked Sendable {
 
     static let z2mHost = "localhost"
@@ -22,7 +22,7 @@ final class Z2MIntegrationTests: XCTestCase, @unchecked Sendable {
             ConnectionConfig.clearPersistedSecretsForTests()
         }
         store = await MainActor.run { AppStore() }
-        try await skipIfZ2MUnavailable()
+        try await requireZ2M()
     }
 
     override func tearDown() async throws {
@@ -299,25 +299,11 @@ final class Z2MIntegrationTests: XCTestCase, @unchecked Sendable {
         return false
     }
 
-    private func skipIfZ2MUnavailable() async throws {
-        let maybeURL = await MainActor.run { connectionConfig().webSocketURL }
-        guard let url = maybeURL else {
-            throw XCTSkip("Cannot construct Z2M URL")
-        }
-        let client = await MainActor.run { Z2MWebSocketClient() }
-        do {
-            try await withThrowingTaskGroup(of: Void.self) { group in
-                group.addTask { _ = try await client.connect(url: url) }
-                group.addTask {
-                    try await Task.sleep(for: .seconds(5))
-                    throw URLError(.timedOut)
-                }
-                try await group.next()
-                group.cancelAll()
-            }
-            await client.disconnect()
-        } catch {
-            throw XCTSkip("Z2M not reachable at \(url) — run 'docker compose up -d'. (\(error))")
+    private func requireZ2M() async throws {
+        guard await MockBridgeProbe.isReachable(host: Self.z2mHost, port: Self.z2mPort) else {
+            let message = "Z2M not reachable at \(Self.z2mHost):\(Self.z2mPort) — run 'docker compose up -d'."
+            throw RequiredMockBridgeError.unavailable(message)
         }
     }
+
 }

--- a/docker/seeder/seeder.py
+++ b/docker/seeder/seeder.py
@@ -78,6 +78,9 @@ MQTT_PORT = int(os.environ.get("MQTT_PORT", "1883"))
 Z2M_TOPIC = os.environ.get("Z2M_TOPIC", "zigbee2mqtt")
 MODE = os.environ.get("MODE", "continuous")            # "once" | "continuous"
 SEED_INTERVAL = int(os.environ.get("SEED_INTERVAL", "60"))
+DRIFT_ON_CLIENT_CONNECT = os.environ.get("DRIFT_ON_CLIENT_CONNECT", "1").lower() not in {
+    "0", "false", "no"
+}
 OTA_TICK_MS = int(os.environ.get("OTA_TICK_MS", "400"))
 OTA_STEP = int(os.environ.get("OTA_STEP", "10"))
 
@@ -842,7 +845,8 @@ def on_message(client, userdata, msg):
         # app's Activity log has at least one state-diff entry ready by
         # the time it reaches the Logs view. Delay long enough for the
         # retained-message replay to finish ingesting in the client.
-        threading.Timer(1.0, lambda: drift_tick(client)).start()
+        if DRIFT_ON_CLIENT_CONNECT:
+            threading.Timer(1.0, lambda: drift_tick(client)).start()
         return
 
     if sub.endswith("/set"):


### PR DESCRIPTION
## Summary

- stop Full CI integration tests from creating a WebSocket preflight connection for every test
- disable connection-triggered 173-device drift storms during Full CI while retaining normal UI-test behavior
- fail selected integration tests when the required mock bridge is unavailable instead of hiding failures as skips
- dispatch Fast CI for generated bundle-refresh PRs and squash-merge them automatically after CI succeeds
- add manual dispatch support to Fast CI for protected automation

## Root cause

Every integration test opened a preflight WebSocket and a test WebSocket. Each connection triggered a full 173-device drift burst while the bridge replayed retained state, intermittently exceeding the app’s first-frame timeout. A timeout during preflight became an XCTest skip and a green run; the same timeout during the test became a red run.

## Validation

- Full CI on dev: https://github.com/tashda/Shellbee/actions/runs/31033375627
- all Z2M and multi-bridge integration tests ran and passed with no integration skips
- iPad build passed
- local build-for-testing passed
- workflow YAML, shell syntax, Python syntax, and git diff checks passed