### PR TITLE
fix: align low-battery threshold between Home banner and Devices filter

### DIFF
--- a/Shellbee/Core/Models/NetworkAnalysis.swift
+++ b/Shellbee/Core/Models/NetworkAnalysis.swift
@@ -49,7 +49,7 @@ enum DeviceCondition: String, CaseIterable, Sendable {
         case .online:           return availabilityStatus == .online
         case .offline:          return availabilityStatus == .offline
         case .availabilityOff:  return availabilityStatus == .untracked
-        case .batteryLow:       return (state.battery ?? 100) < DesignTokens.Threshold.lowBattery
+        case .batteryLow:       return DesignTokens.Threshold.isLowBattery(state.battery ?? 100)
         case .weakSignal:       return (state.linkQuality ?? 999) < DesignTokens.Threshold.weakSignal
         case .interviewing:     return device.isInterviewing
         case .unsupported:      return !device.supported

--- a/Shellbee/Features/Devices/DeviceFilterMenu.swift
+++ b/Shellbee/Features/Devices/DeviceFilterMenu.swift
@@ -95,11 +95,7 @@ struct DeviceFilterMenu: View {
             if viewModel.hasActiveFilter {
                 Divider()
                 Button(role: .destructive) {
-                    viewModel.statusFilter = .all
-                    viewModel.categoryFilter = nil
-                    viewModel.vendorFilter = nil
-                    viewModel.typeFilter = nil
-                    viewModel.bridgeFilter = nil
+                    viewModel.clearFilters()
                     refreshSnapshot()
                 } label: {
                     Label("Clear Filters", systemImage: "xmark.circle")

--- a/Shellbee/Features/Devices/DeviceListView.swift
+++ b/Shellbee/Features/Devices/DeviceListView.swift
@@ -275,8 +275,19 @@ private struct DeviceListContent: View {
                 )
             } else if !viewModel.searchText.isEmpty && viewModel.filteredDevices(store: store).isEmpty {
                 ContentUnavailableView.search(text: viewModel.searchText)
+            } else if viewModel.hasActiveFilter && isSingleBridgeListEmpty(store: store) {
+                noMatchingDevicesView
             }
         }
+    }
+
+    /// Recently Added ignores the status filter, so it keeps the list non-empty.
+    private func isSingleBridgeListEmpty(store: AppStore) -> Bool {
+        guard viewModel.filteredDevices(store: store).isEmpty else { return false }
+        if isGrouped, viewModel.showRecents, !viewModel.recentDevices(store: store).isEmpty {
+            return false
+        }
+        return true
     }
 
     // MARK: - Merged multi-bridge mode
@@ -324,7 +335,20 @@ private struct DeviceListContent: View {
                 )
             } else if !viewModel.searchText.isEmpty && allBound.isEmpty {
                 ContentUnavailableView.search(text: viewModel.searchText)
+            } else if viewModel.hasActiveFilter && allBound.isEmpty
+                        && !(viewModel.showRecents && !recentMergedDevices().isEmpty) {
+                noMatchingDevicesView
             }
+        }
+    }
+
+    private var noMatchingDevicesView: some View {
+        ContentUnavailableView {
+            Label("No Matching Devices", systemImage: "line.3.horizontal.decrease.circle")
+        } description: {
+            Text("No device matches the active filters.")
+        } actions: {
+            Button("Clear Filters") { viewModel.clearFilters() }
         }
     }
 

--- a/Shellbee/Features/Devices/DeviceListViewModel.swift
+++ b/Shellbee/Features/Devices/DeviceListViewModel.swift
@@ -194,6 +194,14 @@ final class DeviceListViewModel {
 
     // MARK: - Actions
 
+    func clearFilters() {
+        statusFilter = .all
+        categoryFilter = nil
+        vendorFilter = nil
+        typeFilter = nil
+        bridgeFilter = nil
+    }
+
     func applyQuickFilter(_ filter: DeviceQuickFilter) {
         typeFilter = nil
         statusFilter = .all

--- a/Shellbee/Features/Home/HomeSnapshot.swift
+++ b/Shellbee/Features/Home/HomeSnapshot.swift
@@ -95,7 +95,7 @@ struct HomeSnapshot: Sendable {
         }.count
         lowBatteryDevices = nonCoordinatorDevices.filter {
             guard let battery = (states[$0.friendlyName] ?? [:]).battery else { return false }
-            return battery <= DesignTokens.Threshold.lowBattery
+            return DesignTokens.Threshold.isLowBattery(battery)
         }.count
         weakSignalDevices = nonCoordinatorDevices.filter {
             guard let quality = (states[$0.friendlyName] ?? [:]).linkQuality else { return false }

--- a/Shellbee/Shared/Components/DeviceCard.swift
+++ b/Shellbee/Shared/Components/DeviceCard.swift
@@ -357,7 +357,7 @@ struct DeviceCard: View {
 
     private var powerIcon: String {
         if device.type == .endDevice {
-            return (state.battery ?? 100) <= DesignTokens.Threshold.lowBattery ? "battery.25" : "battery.100"
+            return DesignTokens.Threshold.isLowBattery(state.battery ?? 100) ? "battery.25" : "battery.100"
         }
         return "powerplug.fill"
     }

--- a/Shellbee/Shared/Components/DeviceMetricHelpers.swift
+++ b/Shellbee/Shared/Components/DeviceMetricHelpers.swift
@@ -12,7 +12,7 @@ extension Int {
     }
 
     var batteryColor: Color {
-        if self < DesignTokens.Threshold.lowBattery { return .red }
+        if DesignTokens.Threshold.isLowBattery(self) { return .red }
         if self < 50 { return .orange }
         return .green
     }

--- a/Shellbee/Shared/DesignTokens.swift
+++ b/Shellbee/Shared/DesignTokens.swift
@@ -266,7 +266,7 @@ nonisolated enum DesignTokens {
         static let weakSignal = 40
 
         /// Single predicate so Home, the status filter and the card icons agree.
-        static func isLowBattery(_ level: Int) -> Bool { level <= lowBattery }
+        static func isLowBattery(_ level: Int) -> Bool { level < lowBattery }
     }
 
     /// Proportional layout ratios — multipliers applied to a parent dimension

--- a/Shellbee/Shared/DesignTokens.swift
+++ b/Shellbee/Shared/DesignTokens.swift
@@ -264,6 +264,9 @@ nonisolated enum DesignTokens {
     nonisolated enum Threshold {
         static let lowBattery = 20
         static let weakSignal = 40
+
+        /// Single predicate so Home, the status filter and the card icons agree.
+        static func isLowBattery(_ level: Int) -> Bool { level <= lowBattery }
     }
 
     /// Proportional layout ratios — multipliers applied to a parent dimension

--- a/ShellbeeTests/Unit/DeviceListViewModelTests.swift
+++ b/ShellbeeTests/Unit/DeviceListViewModelTests.swift
@@ -102,21 +102,21 @@ final class DeviceListViewModelTests: XCTestCase, @unchecked Sendable {
         XCTAssertTrue(result.contains { $0.friendlyName == "Office Sensor" })
     }
 
-    // Regression: a device at exactly the threshold must match the filter.
+    // Regression: the filter boundary must be exactly Threshold.isLowBattery.
     @MainActor
-    func testFilterBatteryLowIncludesExactThreshold() {
-        store.apply(.deviceState(
-            friendlyName: "Office Sensor",
-            state: StateFixture.batteryLow(level: DesignTokens.Threshold.lowBattery)
-        ))
+    func testFilterBatteryLowHonoursThresholdBoundary() {
         vm.statusFilter = .batteryLow
-        XCTAssertTrue(vm.filteredDevices(store: store).contains { $0.friendlyName == "Office Sensor" })
-
-        store.apply(.deviceState(
-            friendlyName: "Office Sensor",
-            state: StateFixture.batteryLow(level: DesignTokens.Threshold.lowBattery + 1)
-        ))
-        XCTAssertFalse(vm.filteredDevices(store: store).contains { $0.friendlyName == "Office Sensor" })
+        for level in [DesignTokens.Threshold.lowBattery - 1, DesignTokens.Threshold.lowBattery] {
+            store.apply(.deviceState(
+                friendlyName: "Office Sensor",
+                state: StateFixture.batteryLow(level: level)
+            ))
+            XCTAssertEqual(
+                vm.filteredDevices(store: store).contains { $0.friendlyName == "Office Sensor" },
+                DesignTokens.Threshold.isLowBattery(level),
+                "battery \(level)"
+            )
+        }
     }
 
     @MainActor

--- a/ShellbeeTests/Unit/DeviceListViewModelTests.swift
+++ b/ShellbeeTests/Unit/DeviceListViewModelTests.swift
@@ -102,6 +102,23 @@ final class DeviceListViewModelTests: XCTestCase, @unchecked Sendable {
         XCTAssertTrue(result.contains { $0.friendlyName == "Office Sensor" })
     }
 
+    // Regression: a device at exactly the threshold must match the filter.
+    @MainActor
+    func testFilterBatteryLowIncludesExactThreshold() {
+        store.apply(.deviceState(
+            friendlyName: "Office Sensor",
+            state: StateFixture.batteryLow(level: DesignTokens.Threshold.lowBattery)
+        ))
+        vm.statusFilter = .batteryLow
+        XCTAssertTrue(vm.filteredDevices(store: store).contains { $0.friendlyName == "Office Sensor" })
+
+        store.apply(.deviceState(
+            friendlyName: "Office Sensor",
+            state: StateFixture.batteryLow(level: DesignTokens.Threshold.lowBattery + 1)
+        ))
+        XCTAssertFalse(vm.filteredDevices(store: store).contains { $0.friendlyName == "Office Sensor" })
+    }
+
     @MainActor
     func testFilterWeakSignal() {
         store.apply(.deviceState(

--- a/ShellbeeTests/Unit/HomeSnapshotTests.swift
+++ b/ShellbeeTests/Unit/HomeSnapshotTests.swift
@@ -105,17 +105,19 @@ final class HomeSnapshotTests: XCTestCase {
         XCTAssertEqual(snapshot.weakSignalDevices, 1)
     }
 
-    // Regression: Home banner and status filter must agree at the threshold.
-    func testLowBatteryCountAgreesWithStatusFilterAtThreshold() {
+    // Regression: the Home banner and the status filter it deep-links into must
+    // agree on every side of the threshold.
+    func testLowBatteryCountAgreesWithStatusFilterAcrossThreshold() {
         let sensor = DeviceFixture.sensor()
-        let state = StateFixture.batteryLow(level: DesignTokens.Threshold.lowBattery)
-        let snapshot = makeSnapshot(devices: [sensor], states: [sensor.friendlyName: state])
-
-        XCTAssertEqual(snapshot.lowBatteryDevices, 1)
-        XCTAssertTrue(
-            DeviceCondition.batteryLow.matches(device: sensor, state: state, isAvailable: true),
-            "Home counts this device as low battery, so the status filter must match it too"
-        )
+        let threshold = DesignTokens.Threshold.lowBattery
+        for level in [threshold - 1, threshold, threshold + 1] {
+            let state = StateFixture.batteryLow(level: level)
+            let snapshot = makeSnapshot(devices: [sensor], states: [sensor.friendlyName: state])
+            let matchesFilter = DeviceCondition.batteryLow.matches(
+                device: sensor, state: state, isAvailable: true
+            )
+            XCTAssertEqual(snapshot.lowBatteryDevices == 1, matchesFilter, "battery \(level)")
+        }
     }
 
     // Behavior: the PAN ID label shown on MeshDetailView formats the raw

--- a/ShellbeeTests/Unit/HomeSnapshotTests.swift
+++ b/ShellbeeTests/Unit/HomeSnapshotTests.swift
@@ -105,6 +105,19 @@ final class HomeSnapshotTests: XCTestCase {
         XCTAssertEqual(snapshot.weakSignalDevices, 1)
     }
 
+    // Regression: Home banner and status filter must agree at the threshold.
+    func testLowBatteryCountAgreesWithStatusFilterAtThreshold() {
+        let sensor = DeviceFixture.sensor()
+        let state = StateFixture.batteryLow(level: DesignTokens.Threshold.lowBattery)
+        let snapshot = makeSnapshot(devices: [sensor], states: [sensor.friendlyName: state])
+
+        XCTAssertEqual(snapshot.lowBatteryDevices, 1)
+        XCTAssertTrue(
+            DeviceCondition.batteryLow.matches(device: sensor, state: state, isAvailable: true),
+            "Home counts this device as low battery, so the status filter must match it too"
+        )
+    }
+
     // Behavior: the PAN ID label shown on MeshDetailView formats the raw
     // integer as "PAN 0xXXXX" (uppercase, 4-digit zero-padded).
     func testPanIDTextFormatting() {


### PR DESCRIPTION
## Summary
- route every low-battery check through a single `DesignTokens.Threshold.isLowBattery` predicate, so Home, the Devices status filter and the card icons can't drift apart again
- add a "No Matching Devices" empty state with a Clear Filters action, replacing the blank Devices list when filters hide everything
- share one `DeviceListViewModel.clearFilters()` between the Filter menu and that empty state

`HomeSnapshot` compared `battery <= 20` while `DeviceCondition.batteryLow` compared `battery < 20`. A device sitting exactly on the threshold was announced by the Home banner, but the `Low Battery` status filter it deep-links into matched nothing — and since `DeviceFilterMenuSnapshot` hides zero-count statuses, the filter vanished from the menu too, leaving a blank screen and no way to tell why.

The predicate is strict (`< 20`), matching `NetworkAnalysisTests.testBatteryLowExactlyAt20IsNotLow` and the `weakSignal` threshold, which is already `<` at all four of its call sites. So the banner was over-reporting rather than the filter under-matching; `HomeSnapshot` and `DeviceCard.powerIcon` move onto the strict comparison.

Fixes #141

## Tests
- `DeviceListViewModelTests.testFilterBatteryLowHonoursThresholdBoundary` — the filter boundary is exactly `Threshold.isLowBattery`
- `HomeSnapshotTests.testLowBatteryCountAgreesWithStatusFilterAcrossThreshold` — the banner count and the filter agree on both sides of the threshold, whichever way the threshold is later defined
- verified on the simulator against a bridge reporting a sensor at 20% and at 19%

Before — Home announces the device, tapping through lands on a blank list:

<p>
  <img width="220" alt="Home banner reporting one low battery device" src="https://github.com/user-attachments/assets/276b6fcd-5a05-4072-b6b8-7d887e4d0fc2" />
  <img width="220" alt="Devices tab filtered to Low Battery, showing nothing" src="https://github.com/user-attachments/assets/3d2c6c8c-bd56-46f7-b2e2-68f44ac56ee9" />
</p>

After, sensor at exactly 20% — no phantom banner, so there is no dead link to follow:

<p>
  <img width="220" alt="Home with no low battery row for a sensor at the threshold" src="https://github.com/user-attachments/assets/38f67a9c-dd82-4c20-89b7-6bb206402945" />
</p>

After, sensor at 19% — the banner leads to the device, and filters that match nothing now explain themselves:

<p>
  <img width="220" alt="Home banner reporting one low battery device" src="https://github.com/user-attachments/assets/91b542f1-a990-422d-81f3-02b20f8609bf" />
  <img width="220" alt="Devices tab filtered to Low Battery, listing Office Sensor" src="https://github.com/user-attachments/assets/3c5042c1-0b4d-4226-9099-412bb4276859" />
  <img width="220" alt="No Matching Devices empty state with a Clear Filters action" src="https://github.com/user-attachments/assets/14fddadc-8607-45ab-b96e-f6f802695bb6" />
</p>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

